### PR TITLE
Resize header title according to browser width and center UAF logo in footer at narrow widths, and other mobile fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -125,12 +125,29 @@ header {
     max-width: 15rem;
   }
   h1 {
-    margin-top: -2rem;
+    margin-top: -1rem;
     padding: 0 0 1rem 0;
     font-family: "Yellowtail";
     color: white !important;
-    font-size: 6.75rem;
     text-shadow: 3px 3px 3px #000;
+
+    @media (max-width: 458px) {
+      font-size: 3.25rem;
+      line-height: 0.95;
+      margin-top: -0.5rem;
+    }
+    @media (min-width: 459px) and (max-width: 604px) {
+      font-size: 3.1rem;
+    }
+    @media (min-width: 605px) and (max-width: 704px) {
+      font-size: 4rem;
+    }
+    @media (min-width: 705px) and (max-width: 951px) {
+      font-size: 4.75rem;
+    }
+    @media (min-width: 952px) {
+      font-size: 6.5rem;
+    }
   }
   h2 {
     border-top: 0.25rem solid white;
@@ -166,6 +183,12 @@ footer {
       max-width: 90%;
       display: inline-block;
       margin-top: 0.45rem;
+    }
+    @media (max-width: 768px) {
+      text-align: center;
+      a img {
+        width: 200px;
+      }
     }
   }
   .content.column p {

--- a/src/App.vue
+++ b/src/App.vue
@@ -193,6 +193,9 @@ footer {
   }
   .content.column p {
     width: 90%;
+    @media (max-width: 768px) {
+      width: 100%;
+    }
   }
 }
 </style>

--- a/src/layers.js
+++ b/src/layers.js
@@ -16,6 +16,7 @@ export default [
     title: "2022 Wildfires",
     local: true,
     visible: true,
+    legendClassOverride: "is-one-third",
     legend: `<table class="alaska-wildfires-legend active-fires">
       <tr><td><img src="${getPublicPath()}/images/fire-perimeter.png"/></td><td class="fire-text">Active Fire Perimeters</td></tr>
       <tr><td><img src="${getPublicPath()}/images/large-fire.png"/></td><td class="fire-text">Large Fire</td></tr>


### PR DESCRIPTION
Closes #6.
Closes #24.

To test, load the app and observe the header and footer at different browser widths, or on a mobile device simulator:

- The header title should resize intelligently, ideally staying in single-line form except at extremely narrow browser widths.
- The UAF logo should now be centered and a bit larger at narrow browser widths.