### PR TITLE
Disable single finger map dragging on mobile devices

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="map">
+    <div v-if="this.$L.Browser.mobile" class="has-text-centered">Use two fingers to drag the map.</div>
     <div id="map--leaflet-map" class="leaflet-container"></div>
   </div>
 </template>
@@ -184,7 +185,8 @@ export default {
           crs: this.crs,
           zoomControl: false,
           scrollWheelZoom: false,
-          attributionControl: false
+          attributionControl: false,
+          dragging: !this.$L.Browser.mobile
         },
         this.mapOptions
       );


### PR DESCRIPTION
Closes #5.

To test, make sure:
- Single finger map dragging is disabled on mobile devices (but still works on computers)
- Double finger map dragging still works on mobile devices, and text appears directly above the map to explain this

I've uploaded this branch to a temporary S3 bucket to help us test on actual mobile devices:

http://alaska-wildfires-test.s3-website-us-west-2.amazonaws.com/