### PR TITLE
Add 1900-1999 flammability layer and update 2000-2099 flammability layer description and color map

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -734,7 +734,7 @@ table.alaska-wildfires-legend {
     }
   }
 
-  &.relative-flammability {
+  &.flammability {
     td div {
       &.rf-1 {
         background-color: rgba(221, 221, 221, 0.7);

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -737,19 +737,19 @@ table.alaska-wildfires-legend {
   &.flammability {
     td div {
       &.rf-1 {
-        background-color: rgba(221, 221, 221, 0.7);
+        background-color: #fef0d9;
       }
       &.rf-2 {
-        background-color: rgb(250, 236, 229);
+        background-color: #fdcc8a;
       }
       &.rf-3 {
-        background-color: rgb(234, 140, 121);
+        background-color: #fc8d59;
       }
       &.rf-4 {
-        background-color: rgb(193, 64, 64);
+        background-color: #e34a33;
       }
       &.rf-5 {
-        background-color: rgb(92, 17, 23);
+        background-color: #b30000;
       }
     }
   }

--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -33,6 +33,9 @@
         <map-layer id="historical_fire_perimiters"></map-layer>
       </li>
       <li>
+        <map-layer id="alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem"></map-layer>
+      </li>
+      <li>
         <map-layer id="alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099"></map-layer>
       </li>
     </ul>

--- a/src/components/LegendList.vue
+++ b/src/components/LegendList.vue
@@ -10,6 +10,9 @@
 		<legend-item id="gridded_lightning"></legend-item>
 		<legend-item id="historical_fire_perimiters"></legend-item>
 		<legend-item
+			id="alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem"
+		></legend-item>
+		<legend-item
 			id="alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099"
 		></legend-item>
 	</div>

--- a/src/layers.js
+++ b/src/layers.js
@@ -155,6 +155,7 @@ export default [
     wmsLayerName:
       "alaska_wildfires:alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem",
     zindex: 5,
+    styles: "flammability",
     title: "Historical modeled flammability",
     legend: `<table class="alaska-wildfires-legend flammability">
       <tr><td><div class="rf-1"></div></td><td>Less likely to burn</td></tr>
@@ -171,6 +172,7 @@ export default [
     wmsLayerName:
       "alaska_wildfires:alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099",
     zindex: 5,
+    styles: "flammability",
     title: "Projected flammability",
     legend: `<table class="alaska-wildfires-legend flammability">
       <tr><td><div class="rf-1"></div></td><td>Less likely to burn</td></tr>

--- a/src/layers.js
+++ b/src/layers.js
@@ -150,13 +150,29 @@ export default [
   },
   {
     abstract: `
-          <p>This layer shows output from ALFRESCO, a computer model that simulates the responses of Northern vegetation to climate change. Darker colors mean a greater chance of a region burning <strong>relative</strong> to other areas of the model output. These model projections, for 2000&ndash;2099, can be useful for planning, but they can&rsquo;t predict which specific places will burn.</p>`,
+          <p>This layer shows output from ALFRESCO, a computer model that simulates the responses of Northern vegetation to climate change. Darker colors mean a greater chance of a region burning. These modeled data for the previous century allow for comparison between that century and this one, but do not necessarily match historical fire perimeters.</p>`,
+    id: "alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem",
+    wmsLayerName:
+      "alaska_wildfires:alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem",
+    zindex: 5,
+    title: "Historical modeled flammability",
+    legend: `<table class="alaska-wildfires-legend flammability">
+      <tr><td><div class="rf-1"></div></td><td>Less likely to burn</td></tr>
+      <tr><td><div class="rf-2"></div></td><td></td></tr>
+      <tr><td><div class="rf-3"></div></td><td>More likely to burn</td></tr>
+      <tr><td><div class="rf-4"></div></td><td></td></tr>
+      <tr><td><div class="rf-5"></div></td><td>Much more likely to burn</td></tr>
+    </table>`,
+  },
+  {
+    abstract: `
+          <p>This layer shows output from ALFRESCO, a computer model that simulates the responses of Northern vegetation to climate change. Darker colors mean a greater chance of a region burning. Model projections are for 2000&ndash;2099 using the NCAR-CCSM4 model under the RCP 8.5 emission scenario. These projections can be useful for planning, particularly when compared to historical flammability and historical fires, but they can’t predict which specific places will burn.</p>`,
     id: "alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099",
     wmsLayerName:
       "alaska_wildfires:alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099",
     zindex: 5,
-    title: "Projected relative flammability",
-    legend: `<table class="alaska-wildfires-legend relative-flammability">
+    title: "Projected flammability",
+    legend: `<table class="alaska-wildfires-legend flammability">
       <tr><td><div class="rf-1"></div></td><td>Less likely to burn</td></tr>
       <tr><td><div class="rf-2"></div></td><td></td></tr>
       <tr><td><div class="rf-3"></div></td><td>More likely to burn</td></tr>


### PR DESCRIPTION
This PR:

- Adds a "Historical modeled flammability" layer (1900-1999) using the ALFRESCO CRU TS 4.0 data available from CKAN
- Uses the same color map as the NCR app for both the historical and projected flammability layers, and updates their color keys in the legend accordingly
- Updates the text descriptions for both the historical and projected flammability layers

You can view this work locally or at the following temporary S3 bucket:

http://alaska-wildfires-test-2.s3-website-us-west-2.amazonaws.com/