### PR TITLE
Adds workaround for disappearing zoom controls with Safari

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -5,3 +5,9 @@
 
 /* Import bulma styles */
 @import "~bulma";
+
+/* Workaround for Leaflet https://github.com/Leaflet/Leaflet/issues/8068 */
+.leaflet-control-container .leaflet-top,
+.leaflet-control-container .leaflet-bottom {
+  will-change: transform;
+}


### PR DESCRIPTION
Closes #31 

Test this on Safari ~15.4 macOS & iOS Safari by loading the map in the `main` branch and panning/zooming around.  Watch for the zoom controls vanishing or other glitches in the map (missing tiles or missing markers).  Then load this branch and do the same.  This branch should eliminate that behavior.