### PR TITLE
Use environment variable to set active vs. inactive mode for webapp

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 VUE_APP_GEOSERVER_WMS_URL=https://gs.mapventure.org/geoserver/wms
 VUE_APP_FIRE_FEATURES_URL=https://fire-shim.mapventure.org/fires.geojson
 VUE_APP_VIIRS_URL=https://fire-shim.mapventure.org/viirs.geojson
+VUE_APP_ACTIVE=true

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,11 +17,11 @@
         <div class="container">
           <div class="intro content is-large">
             <p>
-              See current fire information (updated daily) along with work done by
-              University of Alaska researchers and other scientists that shows
-              historical data and estimated future fire conditions. Information
-              about the current fire season comes from the Alaska Interagency
-              Coordination Center and the MesoWest data services.
+              See current fire information (updated daily) along with work done
+              by University of Alaska researchers and other scientists that
+              shows historical data and estimated future fire conditions.
+              Information about the current fire season comes from the Alaska
+              Interagency Coordination Center and the MesoWest data services.
             </p>
             <p>
               The Wildfire Explorer shows data that aids understanding of
@@ -32,14 +32,17 @@
           <div class="content is-large fire-tally-info">
             <b-message>
               <h4>
-                Fire Tally: How does this year&rsquo;s burned acreage compare with past
-                years?
+                Fire Tally: How does this year&rsquo;s burned acreage compare
+                with past years?
               </h4>
               <p>
-                <a href="https://snap.uaf.edu/tools/daily-fire-tally">Use this tool</a> to compare the current year&rsquo;s daily tally of
-                acres burned to high fire years (> 1 million acres burned) since
-                daily tally records began in 2004. See tallies of Alaska acreage
-                burned daily statewide, by fire protection area, and by year.
+                <a href="https://snap.uaf.edu/tools/daily-fire-tally"
+                  >Use this tool</a
+                >
+                to compare the current year&rsquo;s daily tally of acres burned
+                to high fire years (> 1 million acres burned) since daily tally
+                records began in 2004. See tallies of Alaska acreage burned
+                daily statewide, by fire protection area, and by year.
               </p>
             </b-message>
           </div>
@@ -62,8 +65,18 @@
     </div>
     <div v-else>
       <section class="section">
-        <div class="container">
-          <p class="content is-large">This site will be reactivated in April this year.</p>
+        <div class="container content is-large">
+          <h3>Site offline until April, 2023</h3>
+          <p>
+            This map and tool will be restored in April this year, at the start of the
+            2023 wildfire season.
+          </p>
+          <p>
+            Any questions? Email us at
+            <a href="mailto:uaf-snap-data-tools@alaska.edu"
+              >uaf-snap-data-tools@alaska.edu</a
+            >.
+          </p>
         </div>
       </section>
     </div>
@@ -251,8 +264,8 @@ export default {
   data() {
     return {
       // Convert sting to boolean
-      active: process.env.VUE_APP_ACTIVE == 'true'
-    }
+      active: process.env.VUE_APP_ACTIVE == "true",
+    };
   },
   computed: {
     year() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,52 +12,61 @@
       </h2>
     </header>
 
-    <section class="section">
-      <div class="container">
-        <div class="intro content is-large">
-          <p>
-            See current fire information (updated daily) along with work done by
-            University of Alaska researchers and other scientists that shows
-            historical data and estimated future fire conditions. Information
-            about the current fire season comes from the Alaska Interagency
-            Coordination Center and the MesoWest data services.
-          </p>
-          <p>
-            The Wildfire Explorer shows data that aids understanding of
-            Alaska&rsquo;s fire landscape. It is not designed for fire
-            management decision&ndash;making.
-          </p>
-        </div>
-        <div class="content is-large fire-tally-info">
-          <b-message>
-            <h4>
-              Fire Tally: How does this year&rsquo;s burned acreage compare with past
-              years?
-            </h4>
+    <div v-if="active">
+      <section class="section">
+        <div class="container">
+          <div class="intro content is-large">
             <p>
-              <a href="https://snap.uaf.edu/tools/daily-fire-tally">Use this tool</a> to compare the current year&rsquo;s daily tally of
-              acres burned to high fire years (> 1 million acres burned) since
-              daily tally records began in 2004. See tallies of Alaska acreage
-              burned daily statewide, by fire protection area, and by year.
+              See current fire information (updated daily) along with work done by
+              University of Alaska researchers and other scientists that shows
+              historical data and estimated future fire conditions. Information
+              about the current fire season comes from the Alaska Interagency
+              Coordination Center and the MesoWest data services.
             </p>
-          </b-message>
+            <p>
+              The Wildfire Explorer shows data that aids understanding of
+              Alaska&rsquo;s fire landscape. It is not designed for fire
+              management decision&ndash;making.
+            </p>
+          </div>
+          <div class="content is-large fire-tally-info">
+            <b-message>
+              <h4>
+                Fire Tally: How does this year&rsquo;s burned acreage compare with past
+                years?
+              </h4>
+              <p>
+                <a href="https://snap.uaf.edu/tools/daily-fire-tally">Use this tool</a> to compare the current year&rsquo;s daily tally of
+                acres burned to high fire years (> 1 million acres burned) since
+                daily tally records began in 2004. See tallies of Alaska acreage
+                burned daily statewide, by fire protection area, and by year.
+              </p>
+            </b-message>
+          </div>
+          <div class="intro content is-large intro--legend">
+            <p>
+              <img src="@/assets/fire-perimeter.png" />Active fires with mapped
+              perimeters have a &lsquo;halo&rsquo; to show how big they are.
+            </p>
+            <p>
+              Click one or more map layer names to activate. Scroll down to see
+              details on each layer.
+            </p>
+          </div>
         </div>
-        <div class="intro content is-large intro--legend">
-          <p>
-            <img src="@/assets/fire-perimeter.png" />Active fires with mapped
-            perimeters have a &lsquo;halo&rsquo; to show how big they are.
-          </p>
-          <p>
-            Click one or more map layer names to activate. Scroll down to see
-            details on each layer.
-          </p>
-        </div>
-      </div>
-    </section>
+      </section>
 
-    <section class="section">
-      <FireMap></FireMap>
-    </section>
+      <section class="section">
+        <FireMap></FireMap>
+      </section>
+    </div>
+    <div v-else>
+      <section class="section">
+        <div class="container">
+          <p class="content is-large">This site will be reactivated in April this year.</p>
+        </div>
+      </section>
+    </div>
 
     <footer class="footer">
       <div class="container">
@@ -238,6 +247,12 @@ export default {
   name: "App",
   components: {
     FireMap,
+  },
+  data() {
+    return {
+      // Convert sting to boolean
+      active: process.env.VUE_APP_ACTIVE == 'true'
+    }
   },
   computed: {
     year() {


### PR DESCRIPTION
Xref #36.

This PR adds a new environment variable, `VUE_APP_ACTIVE`, that controls whether the web app is active or not. If inactive, everything between the header and footer is replaced with the following message:

> This site will be reactivated in April this year.

`VUE_APP_ACTIVE` is set to `true` by default. To test, try running this before launching the app:

```
export VUE_APP_ACTIVE=false
```

Using an environment variable will allow us to control whether the app is active or not from ElasticBeanstalk's environment settings without changing the code in subsequent years.