### PR TITLE
Update Umami script URL to v2 version

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,7 +49,7 @@
       async
       defer
       data-website-id="b811e2fb-e9a9-4547-8c53-59a75b01cd9d"
-      src="https://umami.snap.uaf.edu/umami.js"
+      src="https://umami.snap.uaf.edu/script.js"
       data-domains="snap.uaf.edu"
       data-do-not-track="true"
     ></script>


### PR DESCRIPTION
This PR updates the Umami script URL to work with Umami v2. I.e., `umami.js` was changed to `script.js`.

You will need the Umami v2 Vagrant VM to test against. If you do not already have this set up, refer to the Vagrant instructions in https://github.com/ua-snap/nccwsc-projects/pull/154.

With the Vagrant VM running, and assuming Umami's port is forwarded to port 9999 of the host, simply change the Umami config in `public/index.html` to:

```
<script
  async
  defer
  data-website-id="b811e2fb-e9a9-4547-8c53-59a75b01cd9d"
  src="http://localhost:9999/script.js"
  data-do-not-track="true"
></script>
```

Note that the `data-domains` attribute has been removed in the code above, for testing.

Then run this webapp locally and verify that your traffic shows up here: http://localhost:9999/websites/b811e2fb-e9a9-4547-8c53-59a75b01cd9d