### PR TITLE
Warning message regarding missing AICC data

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -5,6 +5,7 @@
         <layer-list></layer-list>
       </div>
       <div class="column">
+        <WarningBanner />
         <mv-map
           ref="map"
           :base-layer-options="baseLayerOptions"
@@ -30,6 +31,7 @@ import moment from "moment";
 
 import store from "../store";
 import mapLayers from "../layers";
+import WarningBanner from "./WarningBanner";
 import L from "leaflet";
 import p4l from "proj4leaflet"; // eslint-disable-line
 import leaflet_heat from "leaflet.heat"; // eslint-disable-line
@@ -86,6 +88,7 @@ export default {
     MvMap,
     LayerList,
     LegendList,
+    WarningBanner,
   },
   computed: {
     crs() {

--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -4,16 +4,10 @@
 
     <ul>
       <li>
-        <map-layer id="fires"></map-layer>
+        <map-layer id="spruceadj_3338"></map-layer>
       </li>
       <li>
         <map-layer id="viirs"></map-layer>
-      </li>
-      <li>
-        <map-layer id="lightning_strikes"></map-layer>
-      </li>
-      <li>
-        <map-layer id="spruceadj_3338"></map-layer>
       </li>
       <li>
         <map-layer id="snow_cover_3338"></map-layer>

--- a/src/components/LegendList.vue
+++ b/src/components/LegendList.vue
@@ -1,9 +1,7 @@
 <template>
   <div>
     <h3 class="title is-2">Layer information</h3>
-    <legend-item id="fires"></legend-item>
     <legend-item id="viirs"></legend-item>
-    <legend-item id="lightning_strikes"></legend-item>
     <legend-item id="spruceadj_3338"></legend-item>
     <legend-item id="snow_cover_3338"></legend-item>
     <legend-item id="alaska_landcover_2015"></legend-item>

--- a/src/components/WarningBanner.vue
+++ b/src/components/WarningBanner.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="warning-banner">
+    <b-message
+      title="AICC Fire and Lightning Data Currently Unavailable"
+      type="is-warning"
+      class="warning-banner-box"
+      aria-close-label="Close message"
+      ><p>
+        Thanks for checking out this tool! Right now, the data feeds for the
+        Alaska Interagency Coordination Center's daily fire and lightning data
+        are not being updated. As soon as new data is available to be displayed,
+        this application will be updated with the current fire year's data.
+      </p>
+    </b-message>
+  </div>
+</template>
+<style lang="scss" scoped>
+::v-deep .message-header p:not(:last-child) {
+  margin-bottom: 0;
+}
+.warning-banner-box .media-content p {
+  color: #333;
+
+  a {
+    font-weight: 600;
+  }
+}
+</style>
+<script>
+export default {
+  name: "WarningBanner",
+};
+</script>

--- a/src/layers.js
+++ b/src/layers.js
@@ -143,6 +143,7 @@ export default [
     <p>This is the same information shown on the &ldquo;Smokey the Bear&rdquo; signs!  Fire managers use these ratings to understand the environment that is developing over time. Ratings are used to assess the risk of wildfires for areas of Alaska based on factors such as recent precipitation and buildup of vegetation in an area.  Data are derived from <a href="https://akff.mesowest.org">layers provided by MesoWest Alaska Fires &amp; Fuels website</a>.</p>
     `,
     id: 'spruceadj_3338',
+    visible: true,
     wmsLayerName: 'alaska_wildfires:spruceadj_3338',
     styles: 'alaska_wildfires:spruce_adjective',
     zindex: 10,


### PR DESCRIPTION
This PR adds a short warning message to the top of the fire map that indicates that the AICC data is not being updated and will be available as soon as that endpoint starts being populated. 

Additionally, the new default layer is the Fire Danger Ratings layer.