### PR TITLE
Adds the AQI forecasts as available map layers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -29,8 +29,10 @@
             </p>
             <p>
               The Wildfire Explorer shows data that aids understanding of
-              Alaska&rsquo;s fire landscape. <strong>It is not designed for fire
-              management decision-making</strong>.
+              Alaska&rsquo;s fire landscape.
+              <strong
+                >It is not designed for fire management decision-making</strong
+              >.
             </p>
           </div>
           <div class="content is-large fire-tally-info">
@@ -70,10 +72,10 @@
     <div v-else>
       <section class="section">
         <div class="container content is-large">
-          <h3>Site offline until April, 2023</h3>
+          <h3>Site offline until April, 2025</h3>
           <p>
             This map and tool will be restored in April this year, at the start
-            of the 2023 wildfire season.
+            of the 2025 wildfire season.
           </p>
           <p>
             Any questions? Email us at

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -680,7 +680,7 @@ table.alaska-wildfires-legend {
   &.aqi-forecast {
     td div {
       &.aqi-good {
-        background-color: rgb(0, 228, 0);
+        border: 2px solid rgb(0, 228, 0);
       }
       &.aqi-moderate {
         background-color: rgb(255, 255, 0);

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -122,7 +122,7 @@ export default {
     return {
       mapOptions: {
         zoom: 1,
-        minZoom: 0,
+        minZoom: 1,
         maxZoom: 6,
         center: [65, -152.5],
       },

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -677,6 +677,29 @@ table.alaska-wildfires-legend {
     }
   }
 
+  &.aqi-forecast {
+    td div {
+      &.aqi-good {
+        background-color: rgb(0, 228, 0);
+      }
+      &.aqi-moderate {
+        background-color: rgb(255, 255, 0);
+      }
+      &.aqi-unhealthy-sg {
+        background-color: rgb(255, 126, 0);
+      }
+      &.aqi-unhealthy {
+        background-color: rgb(255, 0, 0);
+      }
+      &.aqi-very-unhealthy {
+        background-color: rgb(143, 63, 151);
+      }
+      &.aqi-hazardous {
+        background-color: rgb(126, 0, 35);
+      }
+    }
+  }
+
   &.alaska-landcover-2015 {
     td div {
       &.l-1 {

--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -37,7 +37,7 @@
         <map-layer id="gridded_lightning" controls="months"></map-layer>
       </li>
       <li>
-        <map-layer id="historical_fire_perimiters"></map-layer>
+        <map-layer id="historical_fire_perimeters"></map-layer>
       </li>
       <li>
         <map-layer

--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -12,13 +12,13 @@
       <li>
         <map-layer id="lightning_strikes"></map-layer>
       </li>
-      <li>Smoke Forecasts</li>
-      <ul>
-        <li><map-layer id="smoke_forecast_6hrs"></map-layer></li>
-        <li><map-layer id="smoke_forecast_12hrs"></map-layer></li>
-        <li><map-layer id="smoke_forecast_24hrs"></map-layer></li>
-        <li><map-layer id="smoke_forecast_48hrs"></map-layer></li>
-      </ul>
+      <li><span class="layer-title">Smoke Forecasts</span></li>
+
+      <li><map-layer id="smoke_forecast_6hrs"></map-layer></li>
+      <li><map-layer id="smoke_forecast_12hrs"></map-layer></li>
+      <li><map-layer id="smoke_forecast_24hrs"></map-layer></li>
+      <li><map-layer id="smoke_forecast_48hrs"></map-layer></li>
+
       <li>
         <map-layer id="spruceadj_3338"></map-layer>
       </li>
@@ -73,6 +73,16 @@ h3.is-4 {
   margin: 2rem 0 0.5rem;
   &.top {
     margin-top: 0;
+  }
+}
+.layer-title {
+  display: inline-block;
+  padding-left: 1ex;
+
+  & span {
+    color: #666;
+    padding: 0;
+    margin: 0;
   }
 }
 </style>

--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -12,12 +12,12 @@
       <li>
         <map-layer id="lightning_strikes"></map-layer>
       </li>
-      <li><span class="layer-title">Smoke Forecasts</span></li>
+      <li><span class="layer-title">Air Quality Index Forecasts</span></li>
 
-      <li><map-layer id="smoke_forecast_6hrs"></map-layer></li>
-      <li><map-layer id="smoke_forecast_12hrs"></map-layer></li>
-      <li><map-layer id="smoke_forecast_24hrs"></map-layer></li>
-      <li><map-layer id="smoke_forecast_48hrs"></map-layer></li>
+      <li><map-layer id="aqi_forecast_6_hrs"></map-layer></li>
+      <li><map-layer id="aqi_forecast_12_hrs"></map-layer></li>
+      <li><map-layer id="aqi_forecast_24_hrs"></map-layer></li>
+      <li><map-layer id="aqi_forecast_48_hrs"></map-layer></li>
 
       <li>
         <map-layer id="spruceadj_3338"></map-layer>

--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -12,6 +12,13 @@
       <li>
         <map-layer id="lightning_strikes"></map-layer>
       </li>
+      <li>Smoke Forecasts</li>
+      <ul>
+        <li><map-layer id="smoke_forecast_6hrs"></map-layer></li>
+        <li><map-layer id="smoke_forecast_12hrs"></map-layer></li>
+        <li><map-layer id="smoke_forecast_24hrs"></map-layer></li>
+        <li><map-layer id="smoke_forecast_48hrs"></map-layer></li>
+      </ul>
       <li>
         <map-layer id="spruceadj_3338"></map-layer>
       </li>

--- a/src/components/LegendItem.vue
+++ b/src/components/LegendItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="{ visible: layer.visible }" class="legend--item block">
-    <h4 class="title is-5" v-html="layer.title"></h4>
+    <h4 class="title is-5" v-html="title"></h4>
     <div class="columns content">
       <div
         class="column"
@@ -32,6 +32,12 @@ export default {
       );
       return this.$store.state.layers[targetLayerIndex];
     },
+    title() {
+      if(this.layer.subtitle) {
+        return this.layer.subtitle
+      }
+      return this.layer.title
+    }
   },
 };
 </script>

--- a/src/components/LegendList.vue
+++ b/src/components/LegendList.vue
@@ -4,6 +4,10 @@
     <legend-item id="fires"></legend-item>
     <legend-item id="viirs"></legend-item>
     <legend-item id="lightning_strikes"></legend-item>
+    <legend-item id="smoke_forecast_6hrs"></legend-item>
+    <legend-item id="smoke_forecast_12hrs"></legend-item>
+    <legend-item id="smoke_forecast_24hrs"></legend-item>
+    <legend-item id="smoke_forecast_48hrs"></legend-item>
     <legend-item id="spruceadj_3338"></legend-item>
     <legend-item id="snow_cover_3338"></legend-item>
     <legend-item id="alaska_landcover_2015"></legend-item>

--- a/src/components/LegendList.vue
+++ b/src/components/LegendList.vue
@@ -12,7 +12,7 @@
     <legend-item id="snow_cover_3338"></legend-item>
     <legend-item id="alaska_landcover_2015"></legend-item>
     <legend-item id="gridded_lightning"></legend-item>
-    <legend-item id="historical_fire_perimiters"></legend-item>
+    <legend-item id="historical_fire_perimeters"></legend-item>
     <legend-item
       id="alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem"
     ></legend-item>

--- a/src/components/LegendList.vue
+++ b/src/components/LegendList.vue
@@ -4,10 +4,10 @@
     <legend-item id="fires"></legend-item>
     <legend-item id="viirs"></legend-item>
     <legend-item id="lightning_strikes"></legend-item>
-    <legend-item id="smoke_forecast_6hrs"></legend-item>
-    <legend-item id="smoke_forecast_12hrs"></legend-item>
-    <legend-item id="smoke_forecast_24hrs"></legend-item>
-    <legend-item id="smoke_forecast_48hrs"></legend-item>
+    <legend-item id="aqi_forecast_6_hrs"></legend-item>
+    <legend-item id="aqi_forecast_12_hrs"></legend-item>
+    <legend-item id="aqi_forecast_24_hrs"></legend-item>
+    <legend-item id="aqi_forecast_48_hrs"></legend-item>
     <legend-item id="spruceadj_3338"></legend-item>
     <legend-item id="snow_cover_3338"></legend-item>
     <legend-item id="alaska_landcover_2015"></legend-item>

--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -2,8 +2,8 @@
   <div
     :id="id"
     :class="{
-      sublayer: id.includes('smoke_forecast'),
-      layer: !id.includes('smoke_forecast'),
+      sublayer: id.includes('aqi_forecast'),
+      layer: !id.includes('aqi_forecast'),
     }"
   >
     <!-- Below, we need @click.prevent because of this: https://github.com/vuejs/vue/issues/3699 -->

--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -61,12 +61,27 @@ export default {
     rendererDefaults() {
       return this.layer.defaults;
     },
+    sublayers() {
+      // Helper to return all sublayers
+      return this.$store.state.layers.filter((layer) =>
+        layer.id.includes("aqi_forecast")
+      );
+    },
   },
   methods: {
     toggleLayer() {
-      this.$store.commit("toggleLayerVisibility", {
-        id: this.id,
-      });
+      if (this.id.includes("aqi_forecast")) {
+        this.sublayers.forEach((layer) => {
+          // When an AQI forecast layer is toggled, turn off all other AQI forecast layers.
+          if (layer.id !== this.id) {
+            this.$store.commit("setLayerVisibility", {
+              id: layer.id,
+              visible: false,
+            });
+          }
+        });
+      }
+      this.$store.commit("toggleLayerVisibility", { id: this.id });
     },
     handleLayerConfigChange(data) {
       // Update defaults so when

--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -1,5 +1,11 @@
 <template>
-  <div :id="id" class="layer">
+  <div
+    :id="id"
+    :class="{
+      sublayer: id.includes('smoke_forecast'),
+      layer: !id.includes('smoke_forecast'),
+    }"
+  >
     <!-- Below, we need @click.prevent because of this: https://github.com/vuejs/vue/issues/3699 -->
 
     <!-- Layer title! -->
@@ -80,6 +86,16 @@ export default {
 <style lang="scss" scoped>
 .layer {
   margin: 5px 0;
+  cursor: pointer;
+  cursor: hand;
+  span.drag {
+    cursor: grab;
+    color: #888;
+  }
+}
+
+.sublayer {
+  margin: 5px 15px;
   cursor: pointer;
   cursor: hand;
   span.drag {

--- a/src/layers.js
+++ b/src/layers.js
@@ -2,6 +2,8 @@ import moment from 'moment';
 
 const currentYear = new Date().getFullYear();
 
+const smokeAbstract = `<p>A predictive map for PM 2.5 concentration, designed to anticipate regions susceptible to heightened particulate matter levels and potential smoke impact from forest fires. By amalgamating meteorological data, geographical features, historical fire occurrences, and air quality monitoring insights, the map will forecast PM 2.5 concentrations using advanced modeling techniques and spatial analysis. This layer can be used to signal potential future air pollution hotspots.</p>`;
+
 export default [
   {
     id: 'fires',
@@ -76,47 +78,39 @@ export default [
   },
   {
     id: 'smoke_forecast_6hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_6hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_6_hrs_wms',
     title: '6 hours',
     legend:
       `Temporary legend for smoke forecast 6 hours.`,
     zindex: 20,
-    styles: 'alaska_wildfires:smoke_forecast',
-    abstract: `
-            <p>Smoke forecast for 6 hours in the future.</p>`,
+    abstract: smokeAbstract
   },
   {
     id: 'smoke_forecast_12hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_12hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_12_hrs_wms',
     title: '12 hours',
     legend:
       `Temporary legend for smoke forecast 12 hours.`,
     zindex: 20,
-    styles: 'alaska_wildfires:smoke_forecast',
-    abstract: `
-            <p>Smoke forecast for 12 hours in the future.</p>`,
+    abstract: smokeAbstract
   },
   {
     id: 'smoke_forecast_24hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_24hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_24_hrs_wms',
     title: '24 hours',
     legend:
       `Temporary legend for smoke forecast 24 hours.`,
     zindex: 20,
-    styles: 'alaska_wildfires:smoke_forecast',
-    abstract: `
-            <p>Smoke forecast for 24 hours in the future.</p>`,
+    abstract: smokeAbstract
   },
   {
     id: 'smoke_forecast_48hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_48hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_48_hrs_wms',
     title: '48 hours',
     legend:
       `Temporary legend for smoke forecast 48 hours.`,
     zindex: 20,
-    styles: 'alaska_wildfires:smoke_forecast',
-    abstract: `
-            <p>Smoke forecast for 48 hours in the future.</p>`,
+    abstract: smokeAbstract
   },
   {
     id: 'viirs',

--- a/src/layers.js
+++ b/src/layers.js
@@ -2,8 +2,20 @@ import moment from 'moment';
 
 const currentYear = new Date().getFullYear();
 
-const aqiAbstract = `<p>A predictive map for Air Quality Index (AQI), designed to anticipate regions susceptible to heightened particulate matter levels and potential smoke impact from forest fires. By amalgamating meteorological data, geographical features, historical fire occurrences, and air quality monitoring insights, the map will forecast AQI using advanced modeling techniques and spatial analysis. This layer can be used to signal potential future air pollution hotspots.</p>
-<p>NOTE: AQI values below 50 are not shown on the map. This is because the map is designed to highlight areas of concern, not areas with good air quality.</p>`;
+const aqiAbstract = `
+
+<p>A predictive map for Air Quality Index (AQI), designed to anticipate regions susceptible to heightened particulate matter levels and potential smoke impact from forest fires. By amalgamating meteorological data, geographical features, historical fire occurrences, and air quality monitoring insights, the map will forecast AQI using advanced modeling techniques and spatial analysis. This layer can be used to signal potential future air pollution hotspots.</p>
+<p>NOTE: `;
+
+const aqiTable = `
+  <table class="alaska-wildfires-legend aqi-forecast">
+    <tr><td><div class="aqi-good"></div></td><td>Good: 0 - 50</td></tr>
+    <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
+    <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
+    <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
+    <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201 - 300</td></tr>
+    <tr><td><div class="aqi-hazardous"></div></td><td>Hazardoud: 301 - 500</td></tr>
+  </table>`
 
 export default [
   {
@@ -81,14 +93,7 @@ export default [
     id: 'aqi_forecast_6_hrs',
     wmsLayerName: 'alaska_wildfires:aqi_forecast_6_hrs',
     title: '6 hours',
-    legend:
-      `<table class="alaska-wildfires-legend aqi-forecast">
-        <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
-        <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
-        <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
-        <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201 - 300</td></tr>
-        <tr><td><div class="aqi-hazardous"></div></td><td>Hazardoud: 301 - 500</td></tr>
-      </table>`,
+    legend: aqiTable,
     zindex: 20,
     styles: 'alaska_wildfires:aqi_forecast',
     abstract: aqiAbstract,
@@ -97,14 +102,7 @@ export default [
     id: 'aqi_forecast_12_hrs',
     wmsLayerName: 'alaska_wildfires:aqi_forecast_12_hrs',
     title: '12 hours',
-    legend:
-      `<table class="alaska-wildfires-legend aqi-forecast">
-        <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
-        <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
-        <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
-        <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201 - 300</td></tr>
-        <tr><td><div class="aqi-hazardous"></div></td><td>Hazardoud: 301 - 500</td></tr>
-      </table>`,
+    legend: aqiTable,
     zindex: 20,
     styles: 'alaska_wildfires:aqi_forecast',
     abstract: aqiAbstract,
@@ -113,14 +111,7 @@ export default [
     id: 'aqi_forecast_24_hrs',
     wmsLayerName: 'alaska_wildfires:aqi_forecast_24_hrs',
     title: '24 hours',
-    legend:
-      `<table class="alaska-wildfires-legend aqi-forecast">
-        <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
-        <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
-        <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
-        <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201 - 300</td></tr>
-        <tr><td><div class="aqi-hazardous"></div></td><td>Hazardoud: 301 - 500</td></tr>
-      </table>`,
+    legend: aqiTable,
     zindex: 20,
     styles: 'alaska_wildfires:aqi_forecast',
     abstract: aqiAbstract,
@@ -129,14 +120,7 @@ export default [
     id: 'aqi_forecast_48_hrs',
     wmsLayerName: 'alaska_wildfires:aqi_forecast_48_hrs',
     title: '48 hours',
-    legend:
-      `<table class="alaska-wildfires-legend aqi-forecast">
-        <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
-        <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
-        <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
-        <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201 - 300</td></tr>
-        <tr><td><div class="aqi-hazardous"></div></td><td>Hazardoud: 301 - 500</td></tr>
-      </table>`,
+    legend: aqiTable,
     zindex: 20,
     styles: 'alaska_wildfires:aqi_forecast',
     abstract: aqiAbstract,

--- a/src/layers.js
+++ b/src/layers.js
@@ -77,40 +77,48 @@ export default [
             <p>Average of detected lightning strikes for Alaska’s wildfire season (May&ndash;August). Calculated by averaging all strikes within a 20&times;20 km area for each month across 30 years (1986&ndash;2015). This layer looks blocky because each square is showing the average for that area.</p><p>Detailed information about this dataset can be found in <a href="https://journals.ametsoc.org/view/journals/apme/59/6/JAMC-D-19-0209.1.xml">this academic paper</a>, and <a href="https://search.dataone.org/view/10.24431_rw1k45z_2020_7_23_23548">the dataset can be downloaded here</a>.`,
   },
   {
-    id: 'smoke_forecast_6hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_6_hrs_wms',
+    id: 'aqi_forecast_6hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_6hrs',
     title: '6 hours',
     legend:
-      `Temporary legend for smoke forecast 6 hours.`,
+      `Temporary legend for AQI forecast 6 hours.`,
     zindex: 20,
-    abstract: smokeAbstract
+    styles: 'alaska_wildfires:aqi_forecast',
+    abstract: `
+            <p>AQI forecast for 6 hours in the future.</p>`,
   },
   {
-    id: 'smoke_forecast_12hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_12_hrs_wms',
+    id: 'aqi_forecast_12hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_12hrs',
     title: '12 hours',
     legend:
-      `Temporary legend for smoke forecast 12 hours.`,
+      `Temporary legend for AQI forecast 12 hours.`,
     zindex: 20,
-    abstract: smokeAbstract
+    styles: 'alaska_wildfires:aqi_forecast',
+    abstract: `
+            <p>AQI forecast for 12 hours in the future.</p>`,
   },
   {
-    id: 'smoke_forecast_24hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_24_hrs_wms',
+    id: 'aqi_forecast_24hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_24hrs',
     title: '24 hours',
     legend:
-      `Temporary legend for smoke forecast 24 hours.`,
+      `Temporary legend for AQI forecast 24 hours.`,
     zindex: 20,
-    abstract: smokeAbstract
+    styles: 'alaska_wildfires:aqi_forecast',
+    abstract: `
+            <p>AQI forecast for 24 hours in the future.</p>`,
   },
   {
-    id: 'smoke_forecast_48hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_48_hrs_wms',
+    id: 'aqi_forecast_48hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_48hrs',
     title: '48 hours',
     legend:
-      `Temporary legend for smoke forecast 48 hours.`,
+      `Temporary legend for AQI forecast 48 hours.`,
     zindex: 20,
-    abstract: smokeAbstract
+    styles: 'alaska_wildfires:aqi_forecast',
+    abstract: `
+            <p>AQI forecast for 48 hours in the future.</p>`,
   },
   {
     id: 'viirs',

--- a/src/layers.js
+++ b/src/layers.js
@@ -158,15 +158,15 @@ export default [
   {
     abstract: `
           <p>Older wildfire perimeters can be interesting to study in relation to newer fires. Previously burned areas often stop new fires from spreading due to a lack of fuel.</p><p>Data are accessed from the Alaska Interagency Coordination Center (AICC) <a href="https://fire.ak.blm.gov/predsvcs/maps.php">data services</a>.</p>`,
-    id: 'historical_fire_perimiters',
-    wmsLayerName: 'historical_fire_perimiters',
+    id: 'historical_fire_perimeters',
+    wmsLayerName: 'historical_fire_perimeters',
     zindex: 10,
     styles: 'historical_fire_polygon_buckets',
     title: 'Historical fire perimeters',
     legend: `<table class="alaska-wildfires-legend historical-fire-perimeters">
             <tr><td><div class="h-40-69"></div></td><td>1940&mdash;1969</td></tr>
             <tr><td><div class="h-70-99"></div></td><td>1970&mdash;1999</td></tr>
-            <tr><td><div class="h-00-17"></div></td><td>2000&mdash;2021</td></tr>
+            <tr><td><div class="h-00-17"></div></td><td>2000&mdash;2023</td></tr>
           </table>`,
   },
   {

--- a/src/layers.js
+++ b/src/layers.js
@@ -75,6 +75,80 @@ export default [
             <p>Average of detected lightning strikes for Alaska’s wildfire season (May&ndash;August). Calculated by averaging all strikes within a 20&times;20 km area for each month across 30 years (1986&ndash;2015). This layer looks blocky because each square is showing the average for that area.</p><p>Detailed information about this dataset can be found in <a href="https://journals.ametsoc.org/view/journals/apme/59/6/JAMC-D-19-0209.1.xml">this academic paper</a>, and <a href="https://search.dataone.org/view/10.24431_rw1k45z_2020_7_23_23548">the dataset can be downloaded here</a>.`,
   },
   {
+    id: 'smoke_forecast_6hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_6hrs',
+    title: '6 hours',
+    // layerName: 'alaska_wildfires:smoke_forecast_6hrs',
+    legend:
+      `Temporary legend for smoke forecast 6 hours.`,
+    zindex: 20,
+    styles: 'alaska_wildfires:smoke_forecast',
+    abstract: `
+            <p>Smoke forecast for 6 hours in the future.</p>`,
+  },
+  {
+    id: 'smoke_forecast_12hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_12hrs',
+    title: '12 hours',
+    // layerName: 'alaska_wildfires:smoke_forecast_12hrs',
+    legend:
+      `Temporary legend for smoke forecast 12 hours.`,
+    zindex: 20,
+    styles: 'alaska_wildfires:smoke_forecast',
+    abstract: `
+            <p>Smoke forecast for 12 hours in the future.</p>`,
+  },
+  {
+    id: 'smoke_forecast_24hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_24hrs',
+    title: '24 hours',
+    // layerName: 'alaska_wildfires:smoke_forecast_24hrs',
+    legend:
+      `Temporary legend for smoke forecast 24 hours.`,
+    zindex: 20,
+    styles: 'alaska_wildfires:smoke_forecast',
+    abstract: `
+            <p>Smoke forecast for 24 hours in the future.</p>`,
+  },
+  {
+    id: 'smoke_forecast_48hrs',
+    wmsLayerName: 'alaska_wildfires:smoke_forecast_48hrs',
+    title: '48 hours',
+    legend:
+      `Temporary legend for smoke forecast 48 hours.`,
+    zindex: 20,
+    styles: 'alaska_wildfires:smoke_forecast',
+    abstract: `
+            <p>Smoke forecast for 48 hours in the future.</p>`,
+  },
+  // {
+  //   id: 'smoke_Forecast',
+  //   wmsLayerName(params) {
+  //     var hour = params.hour;
+  //     return {
+  //       name: `alaska_wildfires:smoke_forecast_${hour}hrs`,
+  //       title: `Smoke Forecast: ${hour} hours in the future`,
+  //     };
+  //   },
+  //   controls: 'hour',
+  //   defaults: {
+  //     hour: 6,
+  //   },
+  //   zindex: 15,
+  //   legend: `<table class="alaska-wildfires-legend lightning-climatology">
+  //             <tr><td><div class="lc-let1"></div></td><td>&lt;1</td></tr>
+  //             <tr><td><div class="lc-6"></div></td><td>6</td></tr>
+  //             <tr><td><div class="lc-13"></div></td><td>13</td></tr>
+  //             <tr><td><div class="lc-19"></div></td><td>19</td></tr>
+  //             <tr><td><div class="lc-26"></div></td><td>26</td></tr>
+  //             <tr><td><div class="lc-32"></div></td><td>32</td></tr>
+  //             <tr><td><div class="lc-39"></div></td><td>39</td></tr>
+  //             <tr><td><div class="lc-gte45"></div></td><td>45+</td></tr>
+  //           </table>`,
+  //   abstract: `
+  //           <p>=Smoke forecast. This forecast is based on the HRRR model, which predicts the movement of smoke from wildfires. The model uses data from the National Weather Service and the National Center for Atmospheric Research. The forecast is updated every hour.</p><p>More information about the HRRR model can be found <a href="https://rapidrefresh.noaa.gov/hrrr/">here</a>.`,
+  // },
+  {
     id: 'viirs',
     wmsLayerName: 'viirs',
     title: 'Hotspots, last 48 hours',

--- a/src/layers.js
+++ b/src/layers.js
@@ -1,11 +1,14 @@
-import moment from 'moment';
+import moment from "moment";
 
 const currentYear = new Date().getFullYear();
 
 const aqiAbstract = `
+<p>&lsquo;Good&rsquo; air quality (AQI &le;50) is shown as transparent on the map.</p>
 
-<p>A predictive map for Air Quality Index (AQI), designed to anticipate regions susceptible to heightened particulate matter levels and potential smoke impact from forest fires. By amalgamating meteorological data, geographical features, historical fire occurrences, and air quality monitoring insights, the map will forecast AQI using advanced modeling techniques and spatial analysis. This layer can be used to signal potential future air pollution hotspots.</p>
-<p>NOTE: `;
+<p>This layer shows Air Quality Index (AQI), a measure of how polluted the air is.  <a href="https://www.airnow.gov/aqi/aqi-basics/">Read more about AQI.</a></p>
+
+<p>This layer shows <strong>projected</strong> air quality.  The GEOS data used in this layer have been provided by the Global Modeling and Assimilation Office (GMAO) at NASA Goddard Space Flight Center through the <a href="https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php">online data portal in the NASA Center for Climate Simulation</a>.</p>
+`;
 
 const aqiTable = `
   <table class="alaska-wildfires-legend aqi-forecast">
@@ -14,46 +17,46 @@ const aqiTable = `
     <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
     <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
     <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201 - 300</td></tr>
-    <tr><td><div class="aqi-hazardous"></div></td><td>Hazardoud: 301 - 500</td></tr>
-  </table>`
+    <tr><td><div class="aqi-hazardous"></div></td><td>Hazardous: 301 - 500</td></tr>
+  </table>`;
 
 export default [
   {
-    id: 'fires',
-    wmsLayerName: 'fires',
-    title: currentYear + ' Wildfires',
+    id: "fires",
+    wmsLayerName: "fires",
+    title: currentYear + " Wildfires",
     local: true,
     visible: true,
-    legendClassOverride: 'is-one-third',
+    legendClassOverride: "is-one-third",
     legend:
       `<table class="alaska-wildfires-legend active-fires">
       <tr><td><img src="` +
-      require('@/assets/fire-perimeter.png') +
+      require("@/assets/fire-perimeter.png") +
       `"/></td><td class="fire-text">Active Fire Perimeters</td></tr>
       <tr><td><img src="` +
-      require('@/assets/large-fire.png') +
+      require("@/assets/large-fire.png") +
       `"/></td><td class="fire-text">Large Fire</td></tr>
       <tr><td><img class="small-fire-dot" src="` +
-      require('@/assets/small-fire.png') +
+      require("@/assets/small-fire.png") +
       `"/></td><td class="fire-text">Small Fires</td></tr>
       </table>`,
     abstract:
-      '<p>Active (red) and inactive (gray) fires for the ' +
+      "<p>Active (red) and inactive (gray) fires for the " +
       currentYear +
       ' season, using data from the most recent information from the Alaska Interagency Coordination Center.  Small fires (1 acre or less) are shown with a dot. Larger fires and fires with mapped perimeters have a halo to show their relative size.  Recently-discovered fires may not have a mapped perimeter.</p><p>Data are accessed from the Alaska Interagency Coordination Center (AICC) <a href="https://fire.ak.blm.gov/predsvcs/maps.php">data services</a>.</p>',
   },
   {
-    id: 'lightning_strikes',
-    wmsLayerName: 'lightning_strikes',
-    title: 'Lightning strikes, last 36 hours',
-    layerName: 'alaska_wildfires:lightning_strikes',
+    id: "lightning_strikes",
+    wmsLayerName: "lightning_strikes",
+    title: "Lightning strikes, last 36 hours",
+    layerName: "alaska_wildfires:lightning_strikes",
     legend:
       `<table class="alaska-wildfires-legend lightning">
               <tr><td><div class="positive"><img src="` +
-      require('@/assets/lightning-positive.svg') +
+      require("@/assets/lightning-positive.svg") +
       `"/></div></td><td>Positive</td></tr>
               <tr><td><div class="negative"><img src="` +
-      require('@/assets/lightning-negative.svg') +
+      require("@/assets/lightning-negative.svg") +
       `"/></div></td><td>Negative</td></tr>
               <tr><td><div class="cloud2cloud">•</div></td><td>Cloud to cloud</td></tr>
             </table>`,
@@ -62,7 +65,7 @@ export default [
             <p>Lightning strikes are classified according to the type of charge released. Nearly 95% of lightning strikes carry a negative charge, but positively-charged strikes are much more powerful. This layer shows the last 36 hours of lightning activity; older lightning strikes fade over time.</p><p>Data are accessed from the Alaska Interagency Coordination Center (AICC) <a href="https://fire.ak.blm.gov/predsvcs/maps.php">data services</a>.</p>`,
   },
   {
-    id: 'gridded_lightning',
+    id: "gridded_lightning",
     wmsLayerName(params) {
       var monthName = moment.months(params.month - 1);
       return {
@@ -71,7 +74,7 @@ export default [
         title: `Historical lightning strikes in ${monthName}`,
       };
     },
-    controls: 'months',
+    controls: "months",
     defaults: {
       month: 5,
     },
@@ -90,48 +93,52 @@ export default [
             <p>Average of detected lightning strikes for Alaska’s wildfire season (May&ndash;August). Calculated by averaging all strikes within a 20&times;20 km area for each month across 30 years (1986&ndash;2015). This layer looks blocky because each square is showing the average for that area.</p><p>Detailed information about this dataset can be found in <a href="https://journals.ametsoc.org/view/journals/apme/59/6/JAMC-D-19-0209.1.xml">this academic paper</a>, and <a href="https://search.dataone.org/view/10.24431_rw1k45z_2020_7_23_23548">the dataset can be downloaded here</a>.`,
   },
   {
-    id: 'aqi_forecast_6_hrs',
-    wmsLayerName: 'alaska_wildfires:aqi_forecast_6_hrs',
-    title: '6 hours',
+    id: "aqi_forecast_6_hrs",
+    wmsLayerName: "alaska_wildfires:aqi_forecast_6_hrs",
+    title: "6 hours",
+    subtitle: "Projected Air Quality Index, 6 hours",
     legend: aqiTable,
     zindex: 20,
-    styles: 'alaska_wildfires:aqi_forecast',
+    styles: "alaska_wildfires:aqi_forecast",
     abstract: aqiAbstract,
   },
   {
-    id: 'aqi_forecast_12_hrs',
-    wmsLayerName: 'alaska_wildfires:aqi_forecast_12_hrs',
-    title: '12 hours',
+    id: "aqi_forecast_12_hrs",
+    wmsLayerName: "alaska_wildfires:aqi_forecast_12_hrs",
+    title: "12 hours",
+    subtitle: "Projected Air Quality Index, 12 hours",
     legend: aqiTable,
     zindex: 20,
-    styles: 'alaska_wildfires:aqi_forecast',
+    styles: "alaska_wildfires:aqi_forecast",
     abstract: aqiAbstract,
   },
   {
-    id: 'aqi_forecast_24_hrs',
-    wmsLayerName: 'alaska_wildfires:aqi_forecast_24_hrs',
-    title: '24 hours',
+    id: "aqi_forecast_24_hrs",
+    wmsLayerName: "alaska_wildfires:aqi_forecast_24_hrs",
+    title: "24 hours",
+    subtitle: "Projected Air Quality Index, 24 hours",
     legend: aqiTable,
     zindex: 20,
-    styles: 'alaska_wildfires:aqi_forecast',
+    styles: "alaska_wildfires:aqi_forecast",
     abstract: aqiAbstract,
   },
   {
-    id: 'aqi_forecast_48_hrs',
-    wmsLayerName: 'alaska_wildfires:aqi_forecast_48_hrs',
-    title: '48 hours',
+    id: "aqi_forecast_48_hrs",
+    wmsLayerName: "alaska_wildfires:aqi_forecast_48_hrs",
+    title: "48 hours",
+    subtitle: "Projected Air Quality Index, 48 hours",
     legend: aqiTable,
     zindex: 20,
-    styles: 'alaska_wildfires:aqi_forecast',
+    styles: "alaska_wildfires:aqi_forecast",
     abstract: aqiAbstract,
   },
   {
-    id: 'viirs',
-    wmsLayerName: 'viirs',
-    title: 'Hotspots, last 48 hours',
-    layerName: 'alaska_wildfires:viirs_hotspots',
+    id: "viirs",
+    wmsLayerName: "viirs",
+    title: "Hotspots, last 48 hours",
+    layerName: "alaska_wildfires:viirs_hotspots",
     local: true,
-    legend: `<img src="` + require('@/assets/hotspot-legend.png') + `"/>`,
+    legend: `<img src="` + require("@/assets/hotspot-legend.png") + `"/>`,
     zindex: 100,
     abstract: `<p>&ldquo;Hotspots&rdquo; are places where temperatures are higher than expected. Scientific instruments on satellites can detect hotspots, which helps fire managers discover new wildfires. Individual hotspots are compiled into smooth gradients, where darker colors indicate greater densities of hotspots. Note that the instrument can also detect other hotspots unrelated to wildfire, such as flare stacks at oil drilling facilities on the North Slope of Alaska or even ship exhaust in the ocean.</p><p>Data are accessed from the Alaska Interagency Coordination Center (AICC) <a href="https://fire.ak.blm.gov/predsvcs/maps.php">data services</a>.</p>
             `,
@@ -139,11 +146,11 @@ export default [
   {
     abstract: `
           <p>Land cover classification from the <a href="https://eros.usgs.gov/doi-remote-sensing-activities/2019/usgs/nalcms-release-new-land-cover-north-america">North American Land Change Monitoring System, 2015</a>. Spatial resolution is 30&#8239;m (1 pixel = 30&#8239;m on the ground). Dominant land cover relates to wildfire because it varies across the landscape, and influences how a region may burn. Wildfires often change the dominant land cover type, and many fires have occurred since this layer was created.</p>`,
-    id: 'alaska_landcover_2015',
-    wmsLayerName: 'alaska_wildfires:alaska_landcover_2015',
-    title: 'Land cover types',
+    id: "alaska_landcover_2015",
+    wmsLayerName: "alaska_wildfires:alaska_landcover_2015",
+    title: "Land cover types",
     zindex: 3,
-    legendClassOverride: 'is-one-third', //
+    legendClassOverride: "is-one-third", //
     legend: `<table class="alaska-wildfires-legend alaska-landcover-2015">
             <tr><td><div class="l-1"></div></td><td>Temperate or sub-polar needleleaf forest</td></tr>
             <tr><td><div class="l-2"></div></td><td>Sub-polar taiga needleleaf forest</td></tr>
@@ -165,11 +172,11 @@ export default [
   {
     abstract: `
           <p>Older wildfire perimeters can be interesting to study in relation to newer fires. Previously burned areas often stop new fires from spreading due to a lack of fuel.</p><p>Data are accessed from the Alaska Interagency Coordination Center (AICC) <a href="https://fire.ak.blm.gov/predsvcs/maps.php">data services</a>.</p>`,
-    id: 'historical_fire_perimeters',
-    wmsLayerName: 'historical_fire_perimeters',
+    id: "historical_fire_perimeters",
+    wmsLayerName: "historical_fire_perimeters",
     zindex: 10,
-    styles: 'historical_fire_polygon_buckets',
-    title: 'Historical fire perimeters',
+    styles: "historical_fire_polygon_buckets",
+    title: "Historical fire perimeters",
     legend: `<table class="alaska-wildfires-legend historical-fire-perimeters">
             <tr><td><div class="h-40-69"></div></td><td>1940&mdash;1969</td></tr>
             <tr><td><div class="h-70-99"></div></td><td>1970&mdash;1999</td></tr>
@@ -179,11 +186,11 @@ export default [
   {
     abstract: `
     <p>This layer is derived from the U.S. National Ice Center&rsquo;s Interactive Multisensor Snow and Ice Mapping System, which shows snow and ice coverage over the Northern Hemisphere at 1 km resolution. This map shows only snow coverage as an indicator of potential for early fire during spring in Alaska. <a href="https://usicecenter.gov/Resources/ImsInfo">Visit the data source</a>.</p>`,
-    id: 'snow_cover_3338',
-    wmsLayerName: 'alaska_wildfires:snow_cover_3338',
-    styles: 'alaska_wildfires:snow_cover',
+    id: "snow_cover_3338",
+    wmsLayerName: "alaska_wildfires:snow_cover_3338",
+    styles: "alaska_wildfires:snow_cover",
     zindex: 10,
-    title: 'Today&rsquo;s Snow Cover',
+    title: "Today&rsquo;s Snow Cover",
     legend: `<table class="alaska-wildfires-legend snow-cover">
             <tr><td><div class="sc-open"></div></td><td>Open terrain (no snow)</td></tr>
             <tr><td><div class="sc-snow"></div></td><td>Snow</td></tr>
@@ -193,11 +200,11 @@ export default [
     abstract: `
     <p>This is the same information shown on the &ldquo;Smokey the Bear&rdquo; signs!  Fire managers use these ratings to understand the environment that is developing over time. Ratings are used to assess the risk of wildfires for areas of Alaska based on factors such as recent precipitation and buildup of vegetation in an area.  Data are derived from <a href="https://akff.mesowest.org">layers provided by MesoWest Alaska Fires &amp; Fuels website</a>.</p>
     `,
-    id: 'spruceadj_3338',
-    wmsLayerName: 'alaska_wildfires:spruceadj_3338',
-    styles: 'alaska_wildfires:spruce_adjective',
+    id: "spruceadj_3338",
+    wmsLayerName: "alaska_wildfires:spruceadj_3338",
+    styles: "alaska_wildfires:spruce_adjective",
     zindex: 10,
-    title: 'Today&rsquo;s Fire Danger Ratings',
+    title: "Today&rsquo;s Fire Danger Ratings",
     legend: `<table class="alaska-wildfires-legend smokey-bear">
       <tr><td><div class="sa-1"></div></td><td>Low</td></tr>
       <tr><td><div class="sa-2"></div></td><td>Medium</td></tr>
@@ -210,12 +217,12 @@ export default [
     abstract: `
           <p>This layer shows output from ALFRESCO, a computer model that simulates the responses of Northern vegetation to climate change. Darker colors mean a greater chance of a region burning. These modeled data for the previous century (1900-1999) allow for comparison between that century and this one, but do not necessarily match historical fire perimeters.</p>
           <p>Source data, including additional models and scenarios, <a href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/eeaaca2c-0280-4226-b126-fda42a2b6214">can be downloaded here</a>.</p>`,
-    id: 'alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem',
+    id: "alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem",
     wmsLayerName:
-      'alaska_wildfires:alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem',
+      "alaska_wildfires:alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem",
     zindex: 5,
-    styles: 'flammability',
-    title: 'Historical modeled flammability',
+    styles: "flammability",
+    title: "Historical modeled flammability",
     legend: `<table class="alaska-wildfires-legend flammability">
       <tr><td><div class="rf-1"></div></td><td>Less likely to burn</td></tr>
       <tr><td><div class="rf-2"></div></td><td></td></tr>
@@ -227,12 +234,12 @@ export default [
   {
     abstract: `
           <p>This layer shows output from ALFRESCO, a computer model that simulates the responses of Northern vegetation to climate change. Darker colors mean a greater chance of a region burning. Model projections are for 2000&ndash;2099 using the <a href="https://www.cesm.ucar.edu/models/ccsm">NCAR CCSM4</a> model under the RCP 8.5 emission scenario. These projections can be useful for planning, particularly when compared to historical flammability and historical fires, but they can’t predict which specific places will burn.</p><p>Source data, including additional models and scenarios, <a href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/eeaaca2c-0280-4226-b126-fda42a2b6214">can be downloaded here</a>.</p>`,
-    id: 'alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099',
+    id: "alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099",
     wmsLayerName:
-      'alaska_wildfires:alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099',
+      "alaska_wildfires:alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099",
     zindex: 5,
-    styles: 'flammability',
-    title: 'Projected flammability',
+    styles: "flammability",
+    title: "Projected flammability",
     legend: `<table class="alaska-wildfires-legend flammability">
       <tr><td><div class="rf-1"></div></td><td>Less likely to burn</td></tr>
       <tr><td><div class="rf-2"></div></td><td></td></tr>

--- a/src/layers.js
+++ b/src/layers.js
@@ -2,7 +2,8 @@ import moment from 'moment';
 
 const currentYear = new Date().getFullYear();
 
-const aqiAbstract = `<p>A predictive map for Air Quality Index (AQI), designed to anticipate regions susceptible to heightened particulate matter levels and potential smoke impact from forest fires. By amalgamating meteorological data, geographical features, historical fire occurrences, and air quality monitoring insights, the map will forecast AQI using advanced modeling techniques and spatial analysis. This layer can be used to signal potential future air pollution hotspots.</p>`;
+const aqiAbstract = `<p>A predictive map for Air Quality Index (AQI), designed to anticipate regions susceptible to heightened particulate matter levels and potential smoke impact from forest fires. By amalgamating meteorological data, geographical features, historical fire occurrences, and air quality monitoring insights, the map will forecast AQI using advanced modeling techniques and spatial analysis. This layer can be used to signal potential future air pollution hotspots.</p>
+<p>NOTE: AQI values below 50 are not shown on the map. This is because the map is designed to highlight areas of concern, not areas with good air quality.</p>`;
 
 export default [
   {
@@ -82,7 +83,6 @@ export default [
     title: '6 hours',
     legend:
       `<table class="alaska-wildfires-legend aqi-forecast">
-        <tr><td><div class="aqi-good"></div></td><td>Good: 0 - 50</td></tr>
         <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
         <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
         <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
@@ -99,7 +99,6 @@ export default [
     title: '12 hours',
     legend:
       `<table class="alaska-wildfires-legend aqi-forecast">
-        <tr><td><div class="aqi-good"></div></td><td>Good: 0 - 50</td></tr>
         <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
         <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
         <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
@@ -116,7 +115,6 @@ export default [
     title: '24 hours',
     legend:
       `<table class="alaska-wildfires-legend aqi-forecast">
-        <tr><td><div class="aqi-good"></div></td><td>Good: 0 - 50</td></tr>
         <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
         <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
         <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
@@ -133,7 +131,6 @@ export default [
     title: '48 hours',
     legend:
       `<table class="alaska-wildfires-legend aqi-forecast">
-        <tr><td><div class="aqi-good"></div></td><td>Good: 0 - 50</td></tr>
         <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
         <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
         <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>

--- a/src/layers.js
+++ b/src/layers.js
@@ -78,7 +78,6 @@ export default [
     id: 'smoke_forecast_6hrs',
     wmsLayerName: 'alaska_wildfires:smoke_forecast_6hrs',
     title: '6 hours',
-    // layerName: 'alaska_wildfires:smoke_forecast_6hrs',
     legend:
       `Temporary legend for smoke forecast 6 hours.`,
     zindex: 20,
@@ -90,7 +89,6 @@ export default [
     id: 'smoke_forecast_12hrs',
     wmsLayerName: 'alaska_wildfires:smoke_forecast_12hrs',
     title: '12 hours',
-    // layerName: 'alaska_wildfires:smoke_forecast_12hrs',
     legend:
       `Temporary legend for smoke forecast 12 hours.`,
     zindex: 20,
@@ -102,7 +100,6 @@ export default [
     id: 'smoke_forecast_24hrs',
     wmsLayerName: 'alaska_wildfires:smoke_forecast_24hrs',
     title: '24 hours',
-    // layerName: 'alaska_wildfires:smoke_forecast_24hrs',
     legend:
       `Temporary legend for smoke forecast 24 hours.`,
     zindex: 20,
@@ -121,33 +118,6 @@ export default [
     abstract: `
             <p>Smoke forecast for 48 hours in the future.</p>`,
   },
-  // {
-  //   id: 'smoke_Forecast',
-  //   wmsLayerName(params) {
-  //     var hour = params.hour;
-  //     return {
-  //       name: `alaska_wildfires:smoke_forecast_${hour}hrs`,
-  //       title: `Smoke Forecast: ${hour} hours in the future`,
-  //     };
-  //   },
-  //   controls: 'hour',
-  //   defaults: {
-  //     hour: 6,
-  //   },
-  //   zindex: 15,
-  //   legend: `<table class="alaska-wildfires-legend lightning-climatology">
-  //             <tr><td><div class="lc-let1"></div></td><td>&lt;1</td></tr>
-  //             <tr><td><div class="lc-6"></div></td><td>6</td></tr>
-  //             <tr><td><div class="lc-13"></div></td><td>13</td></tr>
-  //             <tr><td><div class="lc-19"></div></td><td>19</td></tr>
-  //             <tr><td><div class="lc-26"></div></td><td>26</td></tr>
-  //             <tr><td><div class="lc-32"></div></td><td>32</td></tr>
-  //             <tr><td><div class="lc-39"></div></td><td>39</td></tr>
-  //             <tr><td><div class="lc-gte45"></div></td><td>45+</td></tr>
-  //           </table>`,
-  //   abstract: `
-  //           <p>=Smoke forecast. This forecast is based on the HRRR model, which predicts the movement of smoke from wildfires. The model uses data from the National Weather Service and the National Center for Atmospheric Research. The forecast is updated every hour.</p><p>More information about the HRRR model can be found <a href="https://rapidrefresh.noaa.gov/hrrr/">here</a>.`,
-  // },
   {
     id: 'viirs',
     wmsLayerName: 'viirs',

--- a/src/layers.js
+++ b/src/layers.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 const currentYear = new Date().getFullYear();
 
-const smokeAbstract = `<p>A predictive map for PM 2.5 concentration, designed to anticipate regions susceptible to heightened particulate matter levels and potential smoke impact from forest fires. By amalgamating meteorological data, geographical features, historical fire occurrences, and air quality monitoring insights, the map will forecast PM 2.5 concentrations using advanced modeling techniques and spatial analysis. This layer can be used to signal potential future air pollution hotspots.</p>`;
+const aqiAbstract = `<p>A predictive map for Air Quality Index (AQI), designed to anticipate regions susceptible to heightened particulate matter levels and potential smoke impact from forest fires. By amalgamating meteorological data, geographical features, historical fire occurrences, and air quality monitoring insights, the map will forecast AQI using advanced modeling techniques and spatial analysis. This layer can be used to signal potential future air pollution hotspots.</p>`;
 
 export default [
   {
@@ -77,48 +77,72 @@ export default [
             <p>Average of detected lightning strikes for Alaska’s wildfire season (May&ndash;August). Calculated by averaging all strikes within a 20&times;20 km area for each month across 30 years (1986&ndash;2015). This layer looks blocky because each square is showing the average for that area.</p><p>Detailed information about this dataset can be found in <a href="https://journals.ametsoc.org/view/journals/apme/59/6/JAMC-D-19-0209.1.xml">this academic paper</a>, and <a href="https://search.dataone.org/view/10.24431_rw1k45z_2020_7_23_23548">the dataset can be downloaded here</a>.`,
   },
   {
-    id: 'aqi_forecast_6hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_6hrs',
+    id: 'aqi_forecast_6_hrs',
+    wmsLayerName: 'alaska_wildfires:aqi_forecast_6_hrs',
     title: '6 hours',
     legend:
-      `Temporary legend for AQI forecast 6 hours.`,
+      `<table class="alaska-wildfires-legend aqi-forecast">
+        <tr><td><div class="aqi-good"></div></td><td>Good: 0 - 50</td></tr>
+        <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
+        <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
+        <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
+        <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201 - 300</td></tr>
+        <tr><td><div class="aqi-hazardous"></div></td><td>Hazardoud: 301 - 500</td></tr>
+      </table>`,
     zindex: 20,
     styles: 'alaska_wildfires:aqi_forecast',
-    abstract: `
-            <p>AQI forecast for 6 hours in the future.</p>`,
+    abstract: aqiAbstract,
   },
   {
-    id: 'aqi_forecast_12hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_12hrs',
+    id: 'aqi_forecast_12_hrs',
+    wmsLayerName: 'alaska_wildfires:aqi_forecast_12_hrs',
     title: '12 hours',
     legend:
-      `Temporary legend for AQI forecast 12 hours.`,
+      `<table class="alaska-wildfires-legend aqi-forecast">
+        <tr><td><div class="aqi-good"></div></td><td>Good: 0 - 50</td></tr>
+        <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
+        <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
+        <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
+        <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201 - 300</td></tr>
+        <tr><td><div class="aqi-hazardous"></div></td><td>Hazardoud: 301 - 500</td></tr>
+      </table>`,
     zindex: 20,
     styles: 'alaska_wildfires:aqi_forecast',
-    abstract: `
-            <p>AQI forecast for 12 hours in the future.</p>`,
+    abstract: aqiAbstract,
   },
   {
-    id: 'aqi_forecast_24hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_24hrs',
+    id: 'aqi_forecast_24_hrs',
+    wmsLayerName: 'alaska_wildfires:aqi_forecast_24_hrs',
     title: '24 hours',
     legend:
-      `Temporary legend for AQI forecast 24 hours.`,
+      `<table class="alaska-wildfires-legend aqi-forecast">
+        <tr><td><div class="aqi-good"></div></td><td>Good: 0 - 50</td></tr>
+        <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
+        <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
+        <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
+        <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201 - 300</td></tr>
+        <tr><td><div class="aqi-hazardous"></div></td><td>Hazardoud: 301 - 500</td></tr>
+      </table>`,
     zindex: 20,
     styles: 'alaska_wildfires:aqi_forecast',
-    abstract: `
-            <p>AQI forecast for 24 hours in the future.</p>`,
+    abstract: aqiAbstract,
   },
   {
-    id: 'aqi_forecast_48hrs',
-    wmsLayerName: 'alaska_wildfires:smoke_forecast_48hrs',
+    id: 'aqi_forecast_48_hrs',
+    wmsLayerName: 'alaska_wildfires:aqi_forecast_48_hrs',
     title: '48 hours',
     legend:
-      `Temporary legend for AQI forecast 48 hours.`,
+      `<table class="alaska-wildfires-legend aqi-forecast">
+        <tr><td><div class="aqi-good"></div></td><td>Good: 0 - 50</td></tr>
+        <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51 - 100</td></tr>
+        <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101 - 150</td></tr>
+        <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151 - 200</td></tr>
+        <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201 - 300</td></tr>
+        <tr><td><div class="aqi-hazardous"></div></td><td>Hazardoud: 301 - 500</td></tr>
+      </table>`,
     zindex: 20,
     styles: 'alaska_wildfires:aqi_forecast',
-    abstract: `
-            <p>AQI forecast for 48 hours in the future.</p>`,
+    abstract: aqiAbstract,
   },
   {
     id: 'viirs',

--- a/src/store.js
+++ b/src/store.js
@@ -90,6 +90,10 @@ export default new Vuex.Store({
         payload.setTo
       );
     },
+    setLayerVisibility(state, { id, visible }) {
+      const layer = state.layers.find(layer => layer.id === id);
+      layer.visible = visible;
+    },
     /*
 
     Triggered when a parameterized layer's configuration changes.


### PR DESCRIPTION
This PR adds the AQI forecasts as available map layers at 6 hours, 12 hours, 24 hours, and 48 hours. These layers should be mutually exclusive in that only a single one of the layers should be capable of being able to be turned on at a time.

To review:

- Ensure each AQI forecast can only be on when all other AQI forecasts are off
- Ensure that the AQI forecast layer legend and information in the legend all make sense 