### PR TITLE
Fix incomplete map load issue in Safari

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -55,6 +55,10 @@ export default {
       .addTo(this.$options.leaflet.map);
 
     this.addLayers();
+
+    setTimeout(() => {
+      this.$options.leaflet.map.invalidateSize();
+    }, 0);
   },
   watch: {
     // When layer visibility or order changes, re-render


### PR DESCRIPTION
This PR fixes a bug that was preventing the map from loading completely in Safari on initial webapp load:

![image](https://github.com/ua-snap/alaska-wildfires/assets/2566292/63b82b48-6aee-49c3-b0fd-7c6458b0b5d9)

You can simulate the problem by building the webapp and serving it from the `dist` subdirectory locally like this:

```
npm install -g serve
export NODE_ENV=development
git checkout main
npm run build
serve -s dist
```

Then load the app in Safari, and reload repeatedly, to observe that the map (intermittently?) fails to load completely.

To see the fix:

```
export NODE_ENV=development
git checkout safari_map_bug
npm run build
serve -s dist
```

Load & reload in Safari and observe that the map now loads completely 100% of the time.