### PR TITLE
Adds the aqi_24hr property that matches the values shown in Purple Air.

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -283,9 +283,7 @@ export default {
       var markers = [];
 
       geoJson.features.forEach((feature) => {
-        const aqiClassInfo = this.getAqiClassInfo(
-          feature.properties.pm2_5_24hr,
-        );
+        const aqiClassInfo = this.getAqiClassInfo(feature.properties.aqi_24hr);
 
         if (_.isUndefined(aqiClassInfo)) {
           return false;
@@ -298,7 +296,7 @@ export default {
             '<span class="' +
             aqiClassInfo.class +
             '">' +
-            feature.properties.pm2_5_24hr +
+            feature.properties.aqi_24hr +
             "</span>",
         });
 
@@ -316,7 +314,7 @@ export default {
             </p>
 
             <span class="sensor-aqi ${aqiClassInfo.class}">${
-          feature.properties.pm2_5_24hr
+          feature.properties.aqi_24hr
         } &mdash; ${aqiClassInfo.name}</span>
             </p>
             <p class="aqi-explain">${aqiClassInfo.description}</p>


### PR DESCRIPTION
This PR changes what is shown by the Air quality sensors layer to point at the aqi_24hr property that has been computed from the Purple Air 2.5PM concentration from their sensors. The reason why the data didn't match up with what is shown on the [Purple Air Map](https://map.purpleair.com/1/b/m/lb/mAQI/a10/p604800/cC0#8.56/64.3155/-147.0134) website, is that I hadn't converted the output to AQI and it was still being shown as PM 2.5 concentration for the 24 hour average.