### PR TITLE
Requires shift key to be pressed for lat / lon based fire API queries to execute on the map.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -67,7 +67,8 @@
             </p>
             <p>
               Click one or more map layer names to activate. Scroll down to see
-              details on each layer.
+              details on each layer. You can also hold down Shift and click on
+              the map to get data about current conditions at that location.
             </p>
           </div>
         </div>

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -171,7 +171,7 @@ export default {
       mapOptions: {
         zoom: 1,
         minZoom: 1,
-        maxZoom: 12,
+        maxZoom: 5,
         center: [65, -152.5],
       },
       baseLayerOptions: {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -62,6 +62,10 @@ export default {
 
     this.$options.leaflet.map.on("click", this.onMapClick);
 
+    // Adds event listeners to change cursor style when shift key is pressed
+    document.addEventListener("keydown", this.updateCursorStyle);
+    document.addEventListener("keyup", this.updateCursorStyle);
+
     setTimeout(() => {
       this.$options.leaflet.map.invalidateSize();
     }, 0);
@@ -84,9 +88,24 @@ export default {
   methods: {
     // Handle map click event
     onMapClick(e) {
-      const lat = e.latlng.lat.toFixed(2);
-      const lng = e.latlng.lng.toFixed(2);
-      this.fetchLocationData(lat, lng);
+      // Only fetch data if shift key is pressed
+      if (e.originalEvent.shiftKey) {
+        const lat = e.latlng.lat.toFixed(2);
+        const lng = e.latlng.lng.toFixed(2);
+        this.fetchLocationData(lat, lng);
+      }
+    },
+    updateCursorStyle(e) {
+      // Checks for shift key press to change cursor style
+      if (e.key == "Shift") {
+        if (e.type == "keydown") {
+          this.$options.leaflet.map.getContainer().style.cursor = "pointer";
+        } else {
+          this.$options.leaflet.map
+            .getContainer()
+            .style.removeProperty("cursor");
+        }
+      }
     },
     async fetchLocationData(lat, lng) {
       try {
@@ -236,6 +255,5 @@ export default {
 #map--leaflet-map {
   display: block;
   height: 85vh;
-  cursor: pointer;
 }
 </style>


### PR DESCRIPTION
This PR adds new functionality that requires the end user to hold Shift while they click on the map to initiate a fire API query for a given lat / lon. This prevents the user from accidentally missing a fire marker and ending up zooming the map unintentionally.

This has the cursor change from a grab cursor to a pointer cursor and back again after the Shift key is pressed and then let go.