### PR TITLE
Updates AQI forecast to have a set time that each layer is based on (updated daily)

### DIFF
--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -13,9 +13,9 @@
         <map-layer id="lightning_strikes"></map-layer>
       </li>
       <li>
-        <span class="layer-title">Air Quality Index forecasts</span>
+        <div class="layer-title">Air Quality Index forecasts<br><span class="when">from midnight, {{ todayString }}</span></div>
         <ul>
-          <li class="layer-title">since {{ todayString }} midnight</li>
+          
           <li><map-layer id="aqi_forecast_6_hrs"></map-layer></li>
           <li><map-layer id="aqi_forecast_12_hrs"></map-layer></li>
           <li><map-layer id="aqi_forecast_24_hrs"></map-layer></li>
@@ -86,8 +86,12 @@ h3.is-4 {
   }
 }
 .layer-title {
-  // display: inline-block;
   padding-left: 1ex;
   font-weight: 300;
+  line-height: 1;
+  color: #000;
+  span.when {
+    font-size: 1.15rem;
+  }
 }
 </style>

--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -13,8 +13,9 @@
         <map-layer id="lightning_strikes"></map-layer>
       </li>
       <li>
-        <span class="layer-title">Air Quality Index forecasts:</span>
+        <span class="layer-title">Air Quality Index forecasts</span>
         <ul>
+          <li class="layer-title">since {{ todayString }} midnight</li>
           <li><map-layer id="aqi_forecast_6_hrs"></map-layer></li>
           <li><map-layer id="aqi_forecast_12_hrs"></map-layer></li>
           <li><map-layer id="aqi_forecast_24_hrs"></map-layer></li>
@@ -65,6 +66,11 @@ export default {
   name: "LayerList",
   components: {
     "map-layer": MapLayer,
+  },
+  data() {
+    return {
+      todayString: new Date().toLocaleDateString("en-US"),
+    };
   },
 };
 </script>

--- a/src/layers.js
+++ b/src/layers.js
@@ -20,17 +20,6 @@ const aqiTable = `
     <tr><td><div class="aqi-hazardous"></div></td><td>Hazardous: 301&ndash;500</td></tr>
   </table>`;
 
-const today = new Date();
-const tomorrow = new Date();
-const dayAfterTomorrow = new Date();
-
-tomorrow.setDate(today.getDate() + 1);
-dayAfterTomorrow.setDate(today.getDate() + 2);
-
-const todayString = today.toLocaleDateString('en-US');
-const tomorrowString = tomorrow.toLocaleDateString('en-US');
-const dayAfterTomorrowString = dayAfterTomorrow.toLocaleDateString('en-US');
-
 export default [
   {
     id: "fires",
@@ -106,8 +95,8 @@ export default [
   {
     id: "aqi_forecast_6_hrs",
     wmsLayerName: "alaska_wildfires:aqi_forecast_6_hrs",
-    title: `${todayString} 6 AM AKST`,
-    subtitle: `Projected Air Quality Index, ${todayString} 6 AM AKST`,
+    title: "6 Hours",
+    subtitle: "Projected Air Quality Index",
     legend: aqiTable,
     zindex: 20,
     styles: "alaska_wildfires:aqi_forecast",
@@ -116,8 +105,8 @@ export default [
   {
     id: "aqi_forecast_12_hrs",
     wmsLayerName: "alaska_wildfires:aqi_forecast_12_hrs",
-    title: `${todayString} 12 PM AKST`,
-    subtitle: `Projected Air Quality Index, ${todayString}) 12 PM AKST`,
+    title: "12 Hours",
+    subtitle: "Projected Air Quality Index",
     legend: aqiTable,
     zindex: 20,
     styles: "alaska_wildfires:aqi_forecast",
@@ -126,8 +115,8 @@ export default [
   {
     id: "aqi_forecast_24_hrs",
     wmsLayerName: "alaska_wildfires:aqi_forecast_24_hrs",
-    title: `${tomorrowString} 12 AM AKST`,
-    subtitle: `Projected Air Quality Index, ${tomorrowString} 12 AM AKST`,
+    title: "24 Hours",
+    subtitle: "Projected Air Quality Index",
     legend: aqiTable,
     zindex: 20,
     styles: "alaska_wildfires:aqi_forecast",
@@ -136,8 +125,8 @@ export default [
   {
     id: "aqi_forecast_48_hrs",
     wmsLayerName: "alaska_wildfires:aqi_forecast_48_hrs",
-    title: `${dayAfterTomorrowString} 12 AM AKST`,
-    subtitle: `Projected Air Quality Index, ${dayAfterTomorrowString} 12 AM AKST`,
+    title: "48 Hours",
+    subtitle: "Projected Air Quality Index",
     legend: aqiTable,
     zindex: 20,
     styles: "alaska_wildfires:aqi_forecast",

--- a/src/layers.js
+++ b/src/layers.js
@@ -20,6 +20,17 @@ const aqiTable = `
     <tr><td><div class="aqi-hazardous"></div></td><td>Hazardous: 301&ndash;500</td></tr>
   </table>`;
 
+const today = new Date();
+const tomorrow = new Date();
+const dayAfterTomorrow = new Date();
+
+tomorrow.setDate(today.getDate() + 1);
+dayAfterTomorrow.setDate(today.getDate() + 2);
+
+const todayString = today.toLocaleDateString('en-US');
+const tomorrowString = tomorrow.toLocaleDateString('en-US');
+const dayAfterTomorrowString = dayAfterTomorrow.toLocaleDateString('en-US');
+
 export default [
   {
     id: "fires",
@@ -95,8 +106,8 @@ export default [
   {
     id: "aqi_forecast_6_hrs",
     wmsLayerName: "alaska_wildfires:aqi_forecast_6_hrs",
-    title: "6 hours",
-    subtitle: "Projected Air Quality Index, 6 hours",
+    title: `${todayString} 6 AM AKST`,
+    subtitle: `Projected Air Quality Index, ${todayString} 6 AM AKST`,
     legend: aqiTable,
     zindex: 20,
     styles: "alaska_wildfires:aqi_forecast",
@@ -105,8 +116,8 @@ export default [
   {
     id: "aqi_forecast_12_hrs",
     wmsLayerName: "alaska_wildfires:aqi_forecast_12_hrs",
-    title: "12 hours",
-    subtitle: "Projected Air Quality Index, 12 hours",
+    title: `${todayString} 12 PM AKST`,
+    subtitle: `Projected Air Quality Index, ${todayString}) 12 PM AKST`,
     legend: aqiTable,
     zindex: 20,
     styles: "alaska_wildfires:aqi_forecast",
@@ -115,8 +126,8 @@ export default [
   {
     id: "aqi_forecast_24_hrs",
     wmsLayerName: "alaska_wildfires:aqi_forecast_24_hrs",
-    title: "24 hours",
-    subtitle: "Projected Air Quality Index, 24 hours",
+    title: `${tomorrowString} 12 AM AKST`,
+    subtitle: `Projected Air Quality Index, ${tomorrowString} 12 AM AKST`,
     legend: aqiTable,
     zindex: 20,
     styles: "alaska_wildfires:aqi_forecast",
@@ -125,8 +136,8 @@ export default [
   {
     id: "aqi_forecast_48_hrs",
     wmsLayerName: "alaska_wildfires:aqi_forecast_48_hrs",
-    title: "48 hours",
-    subtitle: "Projected Air Quality Index, 48 hours",
+    title: `${dayAfterTomorrowString} 12 AM AKST`,
+    subtitle: `Projected Air Quality Index, ${dayAfterTomorrowString} 12 AM AKST`,
     legend: aqiTable,
     zindex: 20,
     styles: "alaska_wildfires:aqi_forecast",


### PR DESCRIPTION
This PR adds a date to the AQI forecast to indicate when the times 6hrs, 12hrs, 24hrs, and 48hrs are in regards to. This value is updated daily just as the AQI forecasts are updated daily to reflect the newest available forecast from the model.