### PR TITLE
Adds Clear Location button to right of community name selector.

### DIFF
--- a/src/components/FireAPIOutput.vue
+++ b/src/components/FireAPIOutput.vue
@@ -21,9 +21,15 @@
           class="fire-danger-rating"
           :style="{
             backgroundColor: apiOutput.cfd.color,
+            color:
+              apiOutput.cfd.type === 'Low' || apiOutput.cfd.type === 'Extreme'
+                ? '#fff'
+                : '#000',
           }"
-          >{{ apiOutput.cfd.type }}</span
-        >&nbsp;&mdash;
+        >
+          {{ apiOutput.cfd.type }}
+        </span>
+        &nbsp;&mdash;
         <span class="fire-danger-level" v-html="dangerRating"></span>
       </p>
 

--- a/src/components/PlaceSelector.vue
+++ b/src/components/PlaceSelector.vue
@@ -23,9 +23,9 @@
             </template>
           </b-autocomplete>
         </b-field>
-        <button @click="clearSelection" class="button is-clear-location">
+        <div v-if="isPlaceSelected"><b-button type="is-light" @click="clearSelection" class="is-clear-location">
           Clear Location
-        </button>
+        </b-button></div>
       </div>
     </div>
   </div>
@@ -91,14 +91,6 @@
   margin-top: 1.35rem;
 }
 
-.button.is-clear-location {
-  background-color: #f5f5f5;
-  border: 1px solid #ddd;
-  color: #333;
-  &:hover {
-    background-color: #e5e5e5;
-  }
-}
 </style>
 <script>
 import { mapGetters } from "vuex";
@@ -132,7 +124,9 @@ export default {
 
       return [];
     },
-
+    isPlaceSelected() {
+      return this.selected !== undefined
+    },
     ...mapGetters({
       places: "places",
       selected: "selected",

--- a/src/components/PlaceSelector.vue
+++ b/src/components/PlaceSelector.vue
@@ -2,8 +2,8 @@
   <div class="place-selector--wrapper">
     <div class="content">
       <h4 class="title is-5">Find a community by name</h4>
-      <div>
-        <b-field>
+      <div class="selector-container">
+        <b-field class="selector-field">
           <b-autocomplete
             v-model="selectedPlace"
             :data="filteredDataObj"
@@ -23,6 +23,9 @@
             </template>
           </b-autocomplete>
         </b-field>
+        <button @click="clearSelection" class="button is-clear-location">
+          Clear Location
+        </button>
       </div>
     </div>
   </div>
@@ -76,6 +79,26 @@
     font-size: 90%;
   }
 }
+
+.selector-container {
+  display: flex;
+  align-items: center;
+}
+
+.selector-field {
+  flex: 1;
+  margin-right: 1rem;
+  margin-top: 1.35rem;
+}
+
+.button.is-clear-location {
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+  color: #333;
+  &:hover {
+    background-color: #e5e5e5;
+  }
+}
 </style>
 <script>
 import { mapGetters } from "vuex";
@@ -124,6 +147,9 @@ export default {
   methods: {
     async fetchFireAPI(selected) {
       await this.$store.dispatch("fetchFireAPI", selected);
+    },
+    clearSelection() {
+      this.$store.commit("clearSelected");
     },
   },
 };


### PR DESCRIPTION
This PR adds a clear location button to the right of the community name selector that clears both lat / lon and community based fire API output.