### PR TITLE
Sets fire danger text for Low and Extreme to white.

### DIFF
--- a/src/components/FireAPIOutput.vue
+++ b/src/components/FireAPIOutput.vue
@@ -21,9 +21,15 @@
           class="fire-danger-rating"
           :style="{
             backgroundColor: apiOutput.cfd.color,
+            color:
+              apiOutput.cfd.type === 'Low' || apiOutput.cfd.type === 'Extreme'
+                ? '#fff'
+                : '#000',
           }"
-          >{{ apiOutput.cfd.type }}</span
-        >&nbsp;&mdash;
+        >
+          {{ apiOutput.cfd.type }}
+        </span>
+        &nbsp;&mdash;
         <span class="fire-danger-level" v-html="dangerRating"></span>
       </p>
 


### PR DESCRIPTION
This PR sets the color of the text for the dark blue (Low) and dark red (Extreme) fire danger rating text in the fire API output to white. All of the other text colors remain as black.