### PR TITLE
Fixes text highlighting when shift clicking on the map after setting focus on text outside of the map

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -79,6 +79,11 @@ export default {
     setTimeout(() => {
       this.$options.leaflet.map.invalidateSize();
     }, 0);
+
+    // Adds an event listener to prevent layer text selection when shift-clicking on the map
+    this.$options.leaflet.map
+      .getContainer()
+      .addEventListener("mousedown", this.preventShiftClickTextSelection);
   },
   watch: {
     // When layer visibility or order changes, re-render
@@ -96,6 +101,16 @@ export default {
     },
   },
   methods: {
+    // Prevent shift-click text selection
+    preventShiftClickTextSelection(e) {
+      if (e.shiftKey) {
+        // This prevents the default behavior of text selection when shift-clicking on the map
+        e.preventDefault();
+
+        // This prevents the event from propagating to the map click event
+        e.stopPropagation();
+      }
+    },
     // Handle map click event
     onMapClick(e) {
       // Only fetch data if shift key is pressed


### PR DESCRIPTION
This PR fixes the default behavior when holding shift and clicking in the browser which is to highlight text between the last place clicked and the next place clicked after holding shift. This was resulting in the layer menu all being highlighted as described in #83.

For testing, try to run the STR in #83 on both main and on this branch to see the difference in results.

Fixes #83 