### PR TITLE
Lists nearby fires after shift click

### DIFF
--- a/src/components/FireAPIOutput.vue
+++ b/src/components/FireAPIOutput.vue
@@ -122,16 +122,28 @@
         </div>
 
         <!-- Display number of nearby fires -->
-        <div v-if="firesNearbyCount > 0">
+        <div v-if="nearbyFiresPresent">
           <p>
-            There are <strong>{{ firesNearbyCount }}</strong> fires within ~50
+            There are
+            <strong>{{ nearbyFiresCount }} active fires</strong> within ~70
             miles of this location.
           </p>
-          <ul>
-            <li v-for="fire in firesNearbyNames" :key="fire">
-              {{ fire }}
-            </li>
-          </ul>
+          <table class="table">
+            <thead>
+              <tr>
+                <th scope="col">Fire name</th>
+                <th scope="col">Size (acres)</th>
+                <th scope="col">Last updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="fire in nearbyFires" :key="fire.NAME">
+                <td>{{ fire.properties.NAME }}</td>
+                <td>{{ fire.properties.acres }}</td>
+                <td>{{ formatDate(fire.properties.updated) }}</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
@@ -141,6 +153,9 @@
 <script>
 import _ from "lodash";
 import { mapGetters } from "vuex";
+
+// Current time zone offset (used in formatDate below).
+const offset = new Date().getTimezoneOffset();
 
 const fireDangerLevels = {
   Low: `Fuels do not ignite readily from small firebrands although a more intense heat source, such as lightning, may start fires in duff or light fuels.`,
@@ -173,6 +188,12 @@ export default {
         _.isArray(this.apiOutput.hist_fire)
       );
     },
+    nearbyFiresCount() {
+      return this.nearbyFires.length;
+    },
+    nearbyFiresPresent() {
+      return this.nearbyFires !== undefined;
+    },
     dangerRating() {
       return fireDangerLevels[this.apiOutput.cfd.type];
     },
@@ -180,11 +201,15 @@ export default {
       selected: "selected",
       apiOutput: "apiOutput",
       loadingData: "loadingData",
-      firesNearbyCount: "firesNearbyCount",
-      firesNearbyNames: "firesNearbyNames",
+      nearbyFires: "nearbyFires",
     }),
   },
   methods: {
+    formatDate(t) {
+      return this.$moment(parseInt(t))
+        .utcOffset(offset)
+        .format("MMMM D");
+    },
     aqiName(aqi) {
       if (!aqi) {
         throw "Undefined AQI in aqiName";

--- a/src/components/FireAPIOutput.vue
+++ b/src/components/FireAPIOutput.vue
@@ -127,6 +127,11 @@
             There are <strong>{{ firesNearbyCount }}</strong> fires within ~50
             miles of this location.
           </p>
+          <ul>
+            <li v-for="fire in firesNearbyNames" :key="fire">
+              {{ fire }}
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -176,6 +181,7 @@ export default {
       apiOutput: "apiOutput",
       loadingData: "loadingData",
       firesNearbyCount: "firesNearbyCount",
+      firesNearbyNames: "firesNearbyNames",
     }),
   },
   methods: {

--- a/src/components/FireAPIOutput.vue
+++ b/src/components/FireAPIOutput.vue
@@ -120,6 +120,14 @@
             </li>
           </ul>
         </div>
+
+        <!-- Display number of nearby fires -->
+        <div v-if="firesNearbyCount > 0">
+          <p>
+            There are <strong>{{ firesNearbyCount }}</strong> fires within ~50
+            miles of this location.
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -167,6 +175,7 @@ export default {
       selected: "selected",
       apiOutput: "apiOutput",
       loadingData: "loadingData",
+      firesNearbyCount: "firesNearbyCount",
     }),
   },
   methods: {

--- a/src/components/FireAPIOutput.vue
+++ b/src/components/FireAPIOutput.vue
@@ -122,7 +122,7 @@
         </div>
 
         <!-- Display number of nearby fires -->
-        <div v-if="nearbyFiresPresent">
+        <div v-if="nearbyFiresCount > 0">
           <p>
             There are
             <strong>{{ nearbyFiresCount }} active fires</strong> within ~70
@@ -139,11 +139,14 @@
             <tbody>
               <tr v-for="fire in nearbyFires" :key="fire.NAME">
                 <td>{{ fire.properties.NAME }}</td>
-                <td>{{ fire.properties.acres }}</td>
+                <td>{{ formatNumber(fire.properties.acres) }}</td>
                 <td>{{ formatDate(fire.properties.updated) }}</td>
               </tr>
             </tbody>
           </table>
+        </div>
+        <div v-else>
+          There are no active fires within ~70 miles of this location.
         </div>
       </div>
     </div>
@@ -189,7 +192,10 @@ export default {
       );
     },
     nearbyFiresCount() {
-      return this.nearbyFires.length;
+      if (this.nearbyFires) {
+        return this.nearbyFires.length;
+      }
+      return 0;
     },
     nearbyFiresPresent() {
       return this.nearbyFires !== undefined;
@@ -206,9 +212,10 @@ export default {
   },
   methods: {
     formatDate(t) {
-      return this.$moment(parseInt(t))
-        .utcOffset(offset)
-        .format("MMMM D");
+      return this.$moment(parseInt(t)).utcOffset(offset).format("MMMM D");
+    },
+    formatNumber(acres) {
+      return acres.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     },
     aqiName(aqi) {
       if (!aqi) {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -140,42 +140,8 @@ export default {
       document.removeEventListener("keydown", this.updateCursorStyle);
       document.removeEventListener("keyup", this.updateCursorStyle);
     },
-    nearbyFires(lat, lng) {
-      const wfsUrl = "https://gs.mapventure.org/geoserver/wfs";
-      // Define parameters for the WFS requests
-      var pointParams = {
-        service: "WFS",
-        version: "1.1.0",
-        request: "GetFeature",
-        typeName: "alaska_wildfires:fire_points",
-        cql_filter: `Dwithin(the_geom,Point(${lng} ${lat}),1,statute miles)`,
-        outputFormat: "json",
-      };
-
-      var polygonParams = {
-        service: "WFS",
-        version: "1.1.0",
-        request: "GetFeature",
-        typeName: "alaska_wildfires:fire_polygons",
-        cql_filter: `Dwithin(the_geom,Point(${lng} ${lat}),1,statute miles)`,
-        outputFormat: "json",
-      };
-
-      return Promise.all([
-        this.$axios.get(wfsUrl, { params: pointParams }),
-        this.$axios.get(wfsUrl, { params: polygonParams }),
-      ])
-        .then((responses) => {
-          // Process the WFS data for fire points and polygons
-          this.$store.commit("setFiresNearby", responses);
-        })
-        .catch((error) => {
-          console.error("Error fetching WFS data:", error);
-        });
-    },
     async fetchLocationData(lat, lng) {
       try {
-        this.nearbyFires(lat, lng);
         const selected = {
           name: lat + ", " + lng,
           latitude: lat,

--- a/src/store.js
+++ b/src/store.js
@@ -73,7 +73,7 @@ export default new Vuex.Store({
     // Total acres burned for the season
     acresBurned: 0,
 
-    // Fires burning within ~50mi
+    // Fires nearby object containing fires from 50 miles around the selected location
     firesNearby: undefined,
   },
   mutations: {
@@ -215,12 +215,11 @@ export default new Vuex.Store({
     firesNearbyNames(state) {
       // Initialize an empty array to store the names
       let names = [];
-
       state.firesNearby.forEach((fireData) => {
         fireData.data.features.forEach((feature) => {
-          console.log(feature.property.name);
+          console.log(feature.properties.NAME);
           // Push the name property of each feature to the names array
-          names.push(feature.property.name);
+          names.push(feature.properties.NAME);
         });
       });
 

--- a/src/store.js
+++ b/src/store.js
@@ -72,6 +72,9 @@ export default new Vuex.Store({
 
     // Total acres burned for the season
     acresBurned: 0,
+
+    // Fires burning within ~50mi
+    firesNearby: undefined,
   },
   mutations: {
     // This function is used to initialize the layers in the store.
@@ -160,6 +163,9 @@ export default new Vuex.Store({
     setAcresBurned(state, acresBurned) {
       state.acresBurned = acresBurned;
     },
+    setFiresNearby(state, firesNearby) {
+      state.firesNearby = firesNearby;
+    },
     clearSelected(state) {
       state.selected = undefined;
     },
@@ -199,6 +205,27 @@ export default new Vuex.Store({
       // Format number with commas.
       // https://stackoverflow.com/questions/2901102/how-to-format-a-number-with-commas-as-thousands-separators
       return state.acresBurned.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    },
+    firesNearbyCount(state) {
+      return (
+        parseInt(state.firesNearby[0].data.totalFeatures) +
+        parseInt(state.firesNearby[1].data.totalFeatures)
+      );
+    },
+    firesNearbyNames(state) {
+      // Initialize an empty array to store the names
+      let names = [];
+
+      state.firesNearby.forEach((fireData) => {
+        fireData.data.features.forEach((feature) => {
+          console.log(feature.property.name);
+          // Push the name property of each feature to the names array
+          names.push(feature.property.name);
+        });
+      });
+
+      // Return the array of names
+      return names;
     },
   },
   actions: {


### PR DESCRIPTION
Closes #82 

This PR adds the ability to get any nearby fires (within 1º, weirdly, ~70 miles) when picking a place or shift-clicking on the map.

Testing:
 - Choose a place by name that has fires.  (Fairbanks comes to mind!)  Check the output.
 - Choose a place with no nearby fires (Utqiagvik), check how it displays.
 - Play around with the shift-click on arbitrary locations a bit too.

Known issues:
 - We really want to move this functionality into the API, probably, but that can wait. 