### PR TITLE
Merge main to staging (#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Once the application is running, you can access it by opening your web browser a
 
 The app depends on an upstream API.  The location of this API can be changed by setting an environment variable:  `export VUE_APP_SNAP_API_URL=http://development.earthmaps.io/` as required.
 
+The file `src/assets/status.json` is intended to be updated by an external process (Prefect) which handling the data assimilation and backend updates.  The version checked into the repository is suitable for testing.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/public/status.json
+++ b/public/status.json
@@ -1,0 +1,33 @@
+{
+	"updated": "2024062600",
+	"layers": {
+		"wildfires": {
+			"updated": "2024062600",
+			"succeeded": true
+		},
+		"hotspots": {
+			"updated": "2024062600",
+			"succeeded": true
+		},
+		"lightning": {
+			"updated": "2024062600",
+			"succeeded": true
+		},
+		"purpleair": {
+			"updated": "2024062600",
+			"succeeded": true
+		},
+		"aqi_forecast": {
+			"updated": "2024062518",
+			"succeeded": true
+		},
+		"fire_danger": {
+			"updated": "2024062600",
+			"succeeded": true
+		},
+		"snow_cover": {
+			"updated": "2024062600",
+			"succeeded": true
+		}
+	}
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -40,9 +40,12 @@
               <span class="glow"
                 >As of {{ date }}, there are
                 <strong>{{ fireCount }}</strong> active fires, and approximately
-                <strong>{{ acresBurned }}</strong> acres have burned.</span
-              ><br />To compare the current fire year to high fire years
-              since 2004, visit the
+                <strong>{{ acresBurned }}</strong> acres have burned this fire season.</span
+              >
+            </p>
+            <p>
+              To compare the current fire year to high fire years since 2004,
+              visit the
               <a href="https://snap.uaf.edu/tools/daily-fire-tally"
                 >Fire Tally</a
               >
@@ -52,13 +55,12 @@
               <img src="@/assets/fire-perimeter.png" />Active fires with mapped
               perimeters have a &lsquo;halo&rsquo; to show relative size.
             </p>
-            <p>
-              Click one or more map layer names to activate. Scroll down to see
-              details on each layer.<br /><span class="small"
-                >Shift-click inside Alaska to get current conditions at that
-                point.</span
-              >
-            </p>
+            <ul>
+              <li>Click one or more map layer names to activate.</li>
+              <li>
+                Legends are shown below the map, scroll down to see details.
+              </li>
+            </ul>
           </div>
           <div class="intro content is-size-4 clamp">
             <PlaceSelector />
@@ -231,6 +233,7 @@ header {
 }
 
 .glow {
+  font-size: 1.5rem;
   background-color: #f3f7a8;
 }
 
@@ -305,6 +308,7 @@ export default {
   methods: {
     async fetch() {
       await this.$store.dispatch("fetchCommunities");
+      await this.$store.dispatch("fetchUpdateStatus");
     },
   },
 };

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -171,7 +171,7 @@ export default {
       mapOptions: {
         zoom: 1,
         minZoom: 1,
-        maxZoom: 5,
+        maxZoom: 6,
         center: [65, -152.5],
       },
       baseLayerOptions: {
@@ -440,7 +440,19 @@ export default {
       fireLayerGroup.addLayer(fireMarkers);
     },
     processFirePolygonData(data) {
-      firePolygons = this.getGeoJsonLayer(data);
+      let featureHandler = (feature, layer) => {
+        layer.bindPopup(
+          this.getFireMarkerPopupContents({
+            title: feature.properties.NAME,
+            acres: feature.properties.acres,
+            cause: feature.properties.GENERALCAUSE,
+            updated: feature.properties.updated,
+            outdate: feature.properties.OUTDATE,
+            discovered: feature.properties.discovered,
+          }),
+        );
+      };
+      firePolygons = this.getGeoJsonLayer(data, featureHandler);
       fireMarkers = this.getFireMarkers(data);
 
       fireLayerGroup.addLayer(firePolygons);
@@ -575,11 +587,15 @@ export default {
       });
       return this.$L.layerGroup(fireMarkers);
     },
-    getGeoJsonLayer(geoJson) {
-      return this.$L.geoJson(geoJson, {
+    getGeoJsonLayer(geoJson, layerHandler) {
+      let config = {
         style: this.styleFirePolygons,
         pointToLayer: this.firePointFeatureHandler,
-      });
+      };
+      if (layerHandler) {
+        config.onEachFeature = layerHandler;
+      }
+      return this.$L.geoJson(geoJson, config);
     },
     styleFirePolygons(feature) {
       if (this.isFireActive(feature.properties)) {
@@ -589,6 +605,7 @@ export default {
           opacity: 0.8,
           weight: 2,
           fillOpacity: 0.3,
+          className: "fire-polygon",
         };
       } else {
         return {
@@ -597,6 +614,7 @@ export default {
           opacity: 0.8,
           weight: 3,
           fillOpacity: 1,
+          className: "fire-polygon",
         };
       }
     },

--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h3 class="title is-4 top">Now (updated daily)</h3>
+    <h3 class="title is-4 top">Now{{ fireUpdateText }}</h3>
     <ul>
       <li>
         <map-layer id="fires"></map-layer>
@@ -11,21 +11,30 @@
       <li>
         <map-layer id="lightning_strikes"></map-layer>
       </li>
-      <hr>
+      <hr />
       <li>
         <map-layer id="purple_air"></map-layer>
       </li>
       <li>
-        <div class="layer-title">Air quality forecast<br><span class="when">starting at midnight, {{ todayString }}</span></div>
+        <div class="layer-title">
+          Air quality forecast<br /><span class="when">{{
+            aqiUpdateText
+          }}</span>
+        </div>
         <ul class="aqi-forecast-list">
-          
           <li><map-layer small="small" id="aqi_forecast_6_hrs"></map-layer></li>
-          <li><map-layer small="small" id="aqi_forecast_12_hrs"></map-layer></li>
-          <li><map-layer small="small" id="aqi_forecast_24_hrs"></map-layer></li>
-          <li><map-layer small="small" id="aqi_forecast_48_hrs"></map-layer></li>
+          <li>
+            <map-layer small="small" id="aqi_forecast_12_hrs"></map-layer>
+          </li>
+          <li>
+            <map-layer small="small" id="aqi_forecast_24_hrs"></map-layer>
+          </li>
+          <li>
+            <map-layer small="small" id="aqi_forecast_48_hrs"></map-layer>
+          </li>
         </ul>
       </li>
-      <hr>
+      <hr />
       <li>
         <map-layer id="spruceadj_3338"></map-layer>
       </li>
@@ -62,16 +71,23 @@
 
 <script>
 import MapLayer from "./MapLayer";
+import { mapGetters } from "vuex";
 
 export default {
   name: "LayerList",
   components: {
     "map-layer": MapLayer,
   },
-  data() {
-    return {
-      todayString: new Date().toLocaleDateString("en-US"),
-    };
+  computed: {
+    fireUpdateText() {
+      return this.lastDataUpdate
+        ? " (updated " + this.lastDataUpdate + ")"
+        : "";
+    },
+    aqiUpdateText() {
+      return this.aqiUpdate ? "starting at " + this.aqiUpdate : "";
+    },
+    ...mapGetters({ lastDataUpdate: "lastDataUpdate", aqiUpdate: "aqiUpdate" }),
   },
 };
 </script>

--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -110,13 +110,11 @@ export default {
 .layer {
   margin: 5px 0;
   cursor: pointer;
-  cursor: hand;
 }
 
 .sublayer {
   margin: 5px 15px;
   cursor: pointer;
-  cursor: hand;
   &.small {
     margin: 0 15px;
     font-size: 1.25rem;

--- a/src/components/PlaceSelector.vue
+++ b/src/components/PlaceSelector.vue
@@ -2,7 +2,9 @@
   <div class="place-selector mb-6">
     <div class="content">
       <div>
-        <b-field label="Type a community name below to show current conditions at that place:">
+        <b-field
+          label="Type a community name below to show current conditions at that place:"
+        >
           <b-autocomplete
             v-model="placeNameFragment"
             :data="filteredDataObj"
@@ -17,6 +19,9 @@
             <template slot-scope="props">
               <div class="search-item">
                 {{ props.option.name }}
+                <span v-if="props.option.country == 'CA'" class="canada">
+                  ({{ props.option.region }}, Canada)</span
+                >
               </div>
             </template>
           </b-autocomplete>

--- a/src/layers.js
+++ b/src/layers.js
@@ -9,7 +9,7 @@ const aqiAbstract = `
 
 <p>&lsquo;Good&rsquo; air quality (AQI &le;50) is shown as transparent on the map.</p>
 
-<p>The GEOS data used in this layer have been provided by the Global Modeling and Assimilation Office (GMAO) at NASA Goddard Space Flight Center through the <a  target="_blank" href="https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php">online data portal in the NASA Center for Climate Simulation</a>.</p>
+<p>The data used in this layer have been provided by the Global Modeling and Assimilation Office (GMAO) at NASA Goddard Space Flight Center through the <a  target="_blank" href="https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php">online data portal in the NASA Center for Climate Simulation</a>.</p>
 
 <ul>
   <li><a  target="_blank" href="https://www.epa.gov/pm-pollution/particulate-matter-pm-basics">Read about Particulate Matter (PM) basics</a></li>

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,1 @@
 /* global __webpack_public_path__:writable */
-
-module.exports = {
-  publicPath:
-    process.env.NODE_ENV === "production" ? "/tools/alaska-wildfires/" : "",
-};


### PR DESCRIPTION

## Release notes July 2

### External/General:

- Data is now updated twice per day, and the time of the last update is shown in the layer list
- When you pick a community or point, active fires within 70 miles are listed

### Internal/Detailed:

- Only exterior (not interior) air sensors are now being pulled into the map
- Removed “GEOS” from AQI Forecast data credit section (Kyle)
- Added “...this fire season” to end of highlighted tally blurb (Mike)
- Reduced page load size by resizing accidentally huge fire photo, whoops
- Clicking anywhere on a fire polygon now opens the popup.  Before, you needed to click on the round ‘halo’ even if the fire polygon was larger than the halo at high zoom levels
- Places in Canada are now labeled (who knew there was a Minto, Canada too?)
- Maximum zoom level increased by one step.  Any more, and we confront infinity
