### PR TITLE
Use actual date of last fire update to report current fire count/tally

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,2 @@
 VUE_APP_GEOSERVER_WMS_URL=https://gs.mapventure.org/geoserver/wms
-VUE_APP_FIRE_FEATURES_URL=https://fire-shim.mapventure.org/fires.geojson
-VUE_APP_VIIRS_URL=https://fire-shim.mapventure.org/viirs.geojson
 VUE_APP_ACTIVE=true

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,11 +36,12 @@
           </div>
 
           <div class="intro content is-size-4 clamp">
-            <p v-if="fireCount > 0">
+            <p v-if="fireUpdateDate">
               <span class="glow"
-                >As of {{ date }}, there are
+                >As of {{ dataDate }}, there are
                 <strong>{{ fireCount }}</strong> active fires, and approximately
-                <strong>{{ acresBurned }}</strong> acres have burned this fire season.</span
+                <strong>{{ acresBurned }}</strong> acres have burned this fire
+                season.</span
               >
             </p>
             <p>
@@ -290,14 +291,14 @@ export default {
     year() {
       return new Date().getFullYear();
     },
-    date() {
-      return new Date().toLocaleDateString("en-US", {
-        month: "long",
-        day: "numeric",
-        year: "numeric",
-      });
+    fireCountPresent() {
+      return this.fireUpdateDate && this.fireCount > 0;
+    },
+    dataDate() {
+      return this.fireUpdateDate.format("MMMM D, YYYY");
     },
     ...mapGetters({
+      fireUpdateDate: "fireUpdateDate",
       fireCount: "fireCount",
       acresBurned: "acresBurned",
     }),

--- a/src/store.js
+++ b/src/store.js
@@ -172,9 +172,14 @@ export default new Vuex.Store({
     loadingData(state) {
       return state.pendingHttpRequests > 0;
     },
-    lastDataUpdate(state) {
+    fireUpdateDate(state) {
+      if(state.updateStatus) {
+        return moment(state.updateStatus.updated, "YYYYMMDDHH")
+      }
+    },
+    lastDataUpdate(state, getters) {
       if (state.updateStatus) {
-        return moment(state.updateStatus.updated, "YYYYMMDDHH").format(
+        return getters.fireUpdateDate.format(
           "ha, MMMM D",
         );
       }


### PR DESCRIPTION
Testing:

 - Run the app.  Note that the date shown in the highlighted blurb now uses the date in the `status.json` file.
 - Comment out line 312 in `App.vue` to simulate failure to load the `status.json` file.  Observe that the highlighted fire count/tally blurb is not shown / there is no console error.
 - Code note: this PR also flushes out some old stuff in the default env file.