### PR TITLE
Attach event recording to a few situations on the page

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -339,6 +339,11 @@ export default {
         // Bind popup to marker
         marker.bindPopup(popupContent);
 
+        // Attach analytics
+        marker.on("click", () => {
+          window.umami.track("aqi-marker-click");
+        });
+
         // Push the marker to the markers array
         markers.push(marker);
       });
@@ -595,7 +600,10 @@ export default {
                   },
                   popupOptions,
                 ),
-              ),
+              )
+              .on("click", () => {
+                window.umami.track("fire-marker-click");
+              }),
           );
         }
       });
@@ -683,7 +691,11 @@ export default {
             },
             popupOptions,
           ),
-        );
+        )
+        .on("click", () => {
+          // Attach analytics
+          window.umami.track("fire-marker-click");
+        });
     },
     // For this method, fireInfo must contain properties
     // title, acres, cause, updated, outdate

--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -78,6 +78,7 @@ export default {
   },
   methods: {
     toggleLayer() {
+      window.umami.track("toggle-layer", { id: this.id });
       if (this.id.includes("aqi_forecast")) {
         this.sublayers.forEach((layer) => {
           // When an AQI forecast layer is toggled, turn off all other AQI forecast layers.
@@ -140,7 +141,7 @@ export default {
 .layer-blurb {
   display: block;
   font-weight: 300;
-  font-size: 1.10rem;
+  font-size: 1.1rem;
   margin-left: 2rem;
   line-height: 1.1;
 }

--- a/src/components/PlaceSelector.vue
+++ b/src/components/PlaceSelector.vue
@@ -96,6 +96,11 @@ export default {
   watch: {
     community: function (community) {
       if (community) {
+        window.umami.track("community-selected", {
+          id: community.id,
+          name: community.name,
+          region: community.region,
+        });
         this.$store.commit("setSelected", community);
         this.fetchFireAPI(community);
       }


### PR DESCRIPTION
Closes #115 

Testing:

First, bring up your Umami vagrant box.

Update the configuration in `public/index.html` around lines ~46-47 this way:

```
      data-website-id="b811e2fb-e9a9-4547-8c53-59a75b01cd9d"
// delete>>      src="https://umami.snap.uaf.edu/script.js"
// delete>>      data-domains="alaskawildfires.org"
// add>>      src="http://localhost:9999/script.js"
```

Next, open the Umami console at http://localhost:9999 and make sure that page visits are being recorded.

The following should generate events (may need to bounce on Refresh on the Umami page to see them!):
- toggling a layer (records layer ID as well)
- clicking on an AQI marker
- clicking on a fire marker (point or poly, not distinguished)
- choosing a community (records community ID, name and region as well)

Visit the "Event Data" tab and you can click on the name of the event (!! did not know that) to drill down into the stats further.