### PR TITLE
Updates the Wildfire Explorer store to use the returned API output for nearby fires' geometries

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ To install and run this project locally, follow these steps:
 4. Start the application:
 
    ```
-   npm run serve
+   npm run dev
    ```
 
 ## Usage
 
 Once the application is running, you can access it by opening your web browser and navigating to `http://localhost:8080`. From there, you can explore the wildfire incidents and view detailed information regarding other available layers related to wildfires in Alaska.
 
-The app depends on an upstream API.  The location of this API can be changed by setting an environment variable:  `export VUE_APP_SNAP_API_URL=http://development.earthmaps.io/` as required.
+The app depends on an upstream API. The location of this API can be changed by setting an environment variable: `export VUE_APP_SNAP_API_URL=http://development.earthmaps.io/` as required.
 
-The file `src/assets/status.json` is intended to be updated by an external process (Prefect) which handling the data assimilation and backend updates.  The version checked into the repository is suitable for testing.
+The file `src/assets/status.json` is intended to be updated by an external process (Prefect) which handling the data assimilation and backend updates. The version checked into the repository is suitable for testing.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "dev": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },


### PR DESCRIPTION
This PR updates the logic in the Vuex store to use the returned nearby fires' geometries from the updated /fire API endpoint. This removes the WFS queries that powered this feature previously as it has been integrated into the API in this PR: https://github.com/ua-snap/data-api/pull/462

To test:
* Run the data API locally on the branch in https://github.com/ua-snap/data-api/pull/462 or just from main now that it is has been merged
* export VUE_APP_SNAP_API_URL=http://localhost:5000
* npm run dev <-- Note the change to use dev rather than serve

Test this functionality by using the search bar in the application for various communities. Try a variety of places to ensure that areas such as Afognak recognize that there are no fires within ~70 miles of that town, and places like Fairbanks still have listed active fires (even if that's only due to the speed at which fires are declared inactive when they are large). 

