### PR TITLE
Updates production Geoserver URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-VUE_APP_GEOSERVER_WMS_URL=https://gs.mapventure.org/geoserver/wms
+VUE_APP_GEOSERVER_WMS_URL=https://gs.earthmaps.io/geoserver/wms
 VUE_APP_ACTIVE=true

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -40,7 +40,7 @@ Object.defineProperty(Vue.prototype, "$L", { value: L });
 Object.defineProperty(Vue.prototype, "$axios", { value: axios });
 Object.defineProperty(Vue.prototype, "$moment", { value: moment });
 
-const wfsUrl = "https://gs.mapventure.org/geoserver/wfs";
+const wfsUrl = "https://gs.earthmaps.io/geoserver/wfs";
 
 // Wire in two listeners that will keep track of open
 // HTTP requests.


### PR DESCRIPTION
This updates our default Geoserver URL to be our new Geoserver instance. This will be required to allow us to retire an old domain name and a much older version of Geoserver.