### PR TITLE
Adds a development environment for AWE

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,3 @@
+VUE_APP_GEOSERVER_WMS_URL=https://gs-dev.earthmaps.io/geoserver/wms
+VUE_APP_GEOSERVER_WFS_URL=https://gs-dev.earthmaps.io/geoserver/wfs
+VUE_APP_ACTIVE=true

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,3 @@
 VUE_APP_GEOSERVER_WMS_URL=https://gs.earthmaps.io/geoserver/wms
+VUE_APP_GEOSERVER_WFS_URL=https://gs.earthmaps.io/geoserver/wfs
 VUE_APP_ACTIVE=true

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -40,8 +40,6 @@ Object.defineProperty(Vue.prototype, "$L", { value: L });
 Object.defineProperty(Vue.prototype, "$axios", { value: axios });
 Object.defineProperty(Vue.prototype, "$moment", { value: moment });
 
-const wfsUrl = "https://gs.earthmaps.io/geoserver/wfs";
-
 // Wire in two listeners that will keep track of open
 // HTTP requests.
 Vue.prototype.$axios.interceptors.request.use(
@@ -78,6 +76,10 @@ var fireLayerGroup;
 var viirsLayerGroup;
 var purpleAirMarkers;
 var purpleAirLayerGroup;
+
+console.log("WMS URL:", process.env.VUE_APP_GEOSERVER_WMS_URL);
+console.log("WFS URL:", process.env.VUE_APP_GEOSERVER_WFS_URL);
+console.log("Active:", process.env.VUE_APP_ACTIVE);
 
 // Current time zone offset (used in parseDate below).
 var offset = new Date().getTimezoneOffset();
@@ -227,7 +229,7 @@ export default {
 
       return new Promise((resolve) => {
         this.$axios
-          .get(wfsUrl, { params })
+          .get(process.env.VUE_APP_GEOSERVER_WFS_URL, { params })
           .then((response) => {
             if (response.data) {
               // Process the WFS data
@@ -363,7 +365,7 @@ export default {
 
       return new Promise((resolve) => {
         this.$axios
-          .get(wfsUrl, { params })
+          .get(process.env.VUE_APP_GEOSERVER_WFS_URL, { params })
           .then((response) => {
             if (response.data) {
               // Process the WFS data
@@ -422,8 +424,12 @@ export default {
       };
 
       return Promise.all([
-        this.$axios.get(wfsUrl, { params: pointParams }),
-        this.$axios.get(wfsUrl, { params: polygonParams }),
+        this.$axios.get(process.env.VUE_APP_GEOSERVER_WFS_URL, {
+          params: pointParams,
+        }),
+        this.$axios.get(process.env.VUE_APP_GEOSERVER_WFS_URL, {
+          params: polygonParams,
+        }),
       ])
         .then((responses) => {
           let fireCount = 0;

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -77,10 +77,6 @@ var viirsLayerGroup;
 var purpleAirMarkers;
 var purpleAirLayerGroup;
 
-console.log("WMS URL:", process.env.VUE_APP_GEOSERVER_WMS_URL);
-console.log("WFS URL:", process.env.VUE_APP_GEOSERVER_WFS_URL);
-console.log("Active:", process.env.VUE_APP_ACTIVE);
-
 // Current time zone offset (used in parseDate below).
 var offset = new Date().getTimezoneOffset();
 


### PR DESCRIPTION
This PR adds the development environment that is pointed at our development Geoserver instance to get data from the July 24, 2024 backup. This will allow us to always be working from actual example data even when the fire season is not in full swing.