### PR TITLE
Updates build command to pull most recent status.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ To set the app into "winter mode", export this env var:
 
 `export VUE_APP_ACTIVE=False`
 
+## Building the repository for production
+
+This repository uses AWS CLI tools to pull the latest version of the status.json file from the production version of the application before building the application. This means that the status.json will match the last time data was updated using our Prefect update scripts.
+
+To use the build command, be sure you have [AWS CLI Toolkit](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed. Then you can run:
+
+```
+npm run build
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "aws s3 cp s3://alaskawildfires.org/status.json . && vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {


### PR DESCRIPTION
This PR updates the `npm run build` command to pull the most recent status.json file to keep the status.json file accurate upon production update. Additionally, this updates the README with instructions to install AWS CLI toolkit in case someone doesn't have that installed as it is a requirement for downloading the status.json file from the S3 bucket.

Closes #145 