### PR TITLE
Adds the fire cause back into fire pop-ups

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -466,7 +466,7 @@ export default {
           this.getFireMarkerPopupContents({
             title: feature.properties.NAME,
             acres: feature.properties.acres,
-            cause: feature.properties.GENERALCAUSE,
+            cause: feature.properties.CAUSE,
             updated: feature.properties.updated,
             outdate: feature.properties.OUTDATE,
             discovered: feature.properties.discovered,
@@ -595,7 +595,7 @@ export default {
                   {
                     title: feature.properties.NAME,
                     acres: feature.properties.acres,
-                    cause: feature.properties.GENERALCAUSE,
+                    cause: feature.properties.CAUSE,
                     updated: feature.properties.updated,
                     outdate: feature.properties.OUTDATE,
                     discovered: feature.properties.discovered,
@@ -686,7 +686,7 @@ export default {
             {
               title: geoJson.properties.NAME,
               acres: geoJson.properties.acres,
-              cause: geoJson.properties.GENERALCAUSE,
+              cause: geoJson.properties.CAUSE,
               updated: geoJson.properties.updated,
               outdate: geoJson.properties.OUTDATE,
               discovered: geoJson.properties.discovered,


### PR DESCRIPTION
This PR adds the cause of the fire back to the list of information contained within each of the fire pop-ups. Clicking on a fire point or polygon will contain the cause section again.

The issue was that when we went from a GeoJSON file to a shapefile, the property "GENERALCAUSE" was too long and was being truncated by the shapefile. Thus, the name was changed to just CAUSE in the Prefect script. This simply modifies the expected property name and the rest of the code still works to show the cause of the fire.

Test by clicking on a few fire points in the map to see if the cause is shown or not.

Closes #137 