### PR TITLE
Guard against fire summary text showing 0's before WFS return

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,7 +36,7 @@
           </div>
 
           <div class="intro content is-size-4 clamp">
-            <p v-if="fireUpdateDate">
+            <p v-if="fireUpdateDate && fireCount">
               <span class="glow"
                 >As of {{ dataDate }}, there are
                 <strong>{{ fireCount }}</strong> active fires, and approximately


### PR DESCRIPTION
Closes #166 

Testing this involves bouncing on the refresh button scrolling down, and noticing that the dynamic text lock only appears with actual data numbers present, not zeros.