### PR TITLE
Populate dropdown with only "awe"-tagged communities

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -279,7 +279,7 @@ export default new Vuex.Store({
   },
   actions: {
     async fetchCommunities(context) {
-      let queryUrl = apiUrl + "/places/communities";
+      let queryUrl = apiUrl + "/places/communities?tags=awe";
       let returnedData = await axios.get(queryUrl);
       context.commit("setPlaces", returnedData);
     },


### PR DESCRIPTION
Closes #150.

This PR uses the Data API's `tags` GET parameter to fetch only the communities that are tagged with the `awe` (Alaska Wildfire Explorer) tag when populating the place selector options.

Communities tagged with the `awe` tag include:

- All communities from our Alaska community CSV (except for the Arctic-EDS-exclusive military sites)
- The Canadian communities from our Yukon and British Columbia CSVs that are within the AQI Forecast data extent (see https://github.com/ua-snap/geospatial-vector-veracity/pull/154 for more info).

The motivation here is to make sure that every selectable community returns meaningful data, or at least that the Data API fetch doesn't return an HTTP error. This is extra important now that we are silently redirecting the users to the front page and resetting the app state if they choose a community that doesn't return data.

To test:

```
cd data-api
export API_GS_BASE_URL=https://gs-dev.earthmaps.io/geoserver/
export FLASK_APP=application.py
pipenv run flask run
```

```
cd alaska-wildfires
export VUE_APP_SNAP_API_URL=http://127.0.0.1:5000
npm run dev
```

Then spot check that:

- Communities from outside Alaska + Canada (e.g., Oslo or Reykjavík) no longer how up as options in the place selector
- Communities within Alaska are still present in the place selector
- Communities within Yukon and British Columbia with the `awe` tag (i.e., within the AQI Forecast extent) show up in the place selector and show meaningful data when selected