### PR TITLE
Add summary section to fire pop-ups

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -599,6 +599,7 @@ export default {
                     updated: feature.properties.updated,
                     outdate: feature.properties.OUTDATE,
                     discovered: feature.properties.discovered,
+                    summary: feature.properties.SUMMARY,
                   },
                   popupOptions,
                 ),
@@ -690,6 +691,7 @@ export default {
               updated: geoJson.properties.updated,
               outdate: geoJson.properties.OUTDATE,
               discovered: geoJson.properties.discovered,
+              summary: geoJson.properties.SUMMARY,
             },
             popupOptions,
           ),
@@ -728,19 +730,25 @@ export default {
           "</h3>"
         : "";
 
+      var summary = fireInfo.summary
+        ? "<strong>Summary</strong>: <code>" + fireInfo.summary + "</code>"
+        : "<strong>Summary</strong>: <code>None provided.</code>";
+
       return _.template(`
   <h1><%= title %></h1>
   <h2><%= acres %></h2>
   <%= discovered %>
   <%= cause %>
   <%= out %>
-  <%= updated %>`)({
+  <%= updated %>
+  <%= summary %>`)({
         title: fireInfo.title,
         acres: acres,
         cause: cause,
         updated: updated,
         out: out,
         discovered: discovered,
+        summary: summary,
       });
     },
     // Helper function to place markers at the centroid

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -731,8 +731,10 @@ export default {
         : "";
 
       var summary = fireInfo.summary
-        ? "<strong>Summary</strong>: <code>" + fireInfo.summary + "</code>"
-        : "<strong>Summary</strong>: <code>None provided.</code>";
+        ? "<strong>Summary</strong>: <div class='fire-summary'>" +
+          fireInfo.summary +
+          "</div>"
+        : "";
 
       return _.template(`
   <h1><%= title %></h1>
@@ -791,6 +793,13 @@ export default {
 .leaflet-popup-content {
   z-index: 1000;
 
+  .fire-summary {
+    width: 30vh;
+    max-height: 30vh;
+    overflow-y: scroll;
+    white-space: pre-wrap;
+  }
+
   h1 {
     font-size: 16pt;
     color: #322323;
@@ -818,7 +827,7 @@ export default {
   p.updated {
     margin-top: 0.25ex;
     font-weight: 300;
-    color: #988989;
+    color: #000;
   }
 
   p.out {


### PR DESCRIPTION
This PR adds a section in the fire point and polygon pop-ups that contains the summary provided by the AICC for each individual fire. Currently, there are only 4 fire points from this year that contain the summary text, which includes two that are down in the Kenai / Homer area.

To see the summary text, you will need to modify your .env.development to have the following line:

VUE_APP_GEOSERVER_WFS_URL=https://gs.earthmaps.io/geoserver/wfs

I've been working on getting our Prefect scripts ready for the new fire season this morning so the fire points were updated on the production server to match the current state of the fires identified in the state.

Let me know if you have any trouble!