### PR TITLE
Updates anchor links to remain the same color and have an underline when hovered over.

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -11,3 +11,8 @@
 .leaflet-control-container .leaflet-bottom {
   will-change: transform;
 }
+
+a:hover {
+  color: hsl(229 53% 48% / 1);
+  text-decoration: underline;
+}

--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -90,7 +90,10 @@ export default {
           }
         });
       }
-      this.$store.commit("toggleLayerVisibility", { id: this.id, router: this.$router });
+      this.$store.commit("toggleLayerVisibility", {
+        id: this.id,
+        router: this.$router,
+      });
     },
     handleLayerConfigChange(data) {
       // Update defaults so when
@@ -108,6 +111,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+a:hover {
+  text-decoration: none;
+}
+
 .layer {
   margin: 5px 0;
   cursor: pointer;


### PR DESCRIPTION
This PR is a simple CSS change to make the anchor links on the page all remain the same color when they are hovered over while adding the underline text decoration. We want this done for all of the anchor links on the page except for the ones that are part of the MapLayer component.

Test by hovering over the anchor links on the page and making sure that the anchor links in the map layer options on the left hand side do not have the underline text decoration.

Closes #123 