### PR TITLE
Load ALFRESCO flammability layer from Rasdaman, not GeoServer

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,4 @@
 VUE_APP_GEOSERVER_WMS_URL=https://gs-dev.earthmaps.io/geoserver/wms
 VUE_APP_GEOSERVER_WFS_URL=https://gs-dev.earthmaps.io/geoserver/wfs
+VUE_APP_RASDAMAN_URL=https://apollo.snap.uaf.edu/rasdaman/ows
 VUE_APP_ACTIVE=true

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,4 @@
 VUE_APP_GEOSERVER_WMS_URL=https://gs.earthmaps.io/geoserver/wms
 VUE_APP_GEOSERVER_WFS_URL=https://gs.earthmaps.io/geoserver/wfs
+VUE_APP_RASDAMAN_URL=https://maps.earthmaps.io/rasdaman/ows
 VUE_APP_ACTIVE=true

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -177,7 +177,7 @@ export default {
         transparent: true,
         srs: "EPSG:3338",
         format: "image/png",
-        version: "1.3",
+        version: "1.3.0",
         continuousWorld: true, // needed for non-3857 projs
       },
       layers: mapLayers,

--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -63,7 +63,7 @@
       </li>
       <li>
         <map-layer
-          id="alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099"
+          id="alfresco_relative_flammability_NCAR-CCSM4_rcp85_2070_2099"
         ></map-layer>
       </li>
     </ul>

--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -58,12 +58,12 @@
       </li>
       <li>
         <map-layer
-          id="alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem"
+          id="alfresco_relative_flammability_cru_ts40_historical_1950_2008_iem"
         ></map-layer>
       </li>
       <li>
         <map-layer
-          id="alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099"
+          id="alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099"
         ></map-layer>
       </li>
     </ul>

--- a/src/components/LegendList.vue
+++ b/src/components/LegendList.vue
@@ -18,7 +18,7 @@
       id="alfresco_relative_flammability_cru_ts40_historical_1950_2008_iem"
     ></legend-item>
     <legend-item
-      id="alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099"
+      id="alfresco_relative_flammability_NCAR-CCSM4_rcp85_2070_2099"
     ></legend-item>
   </div>
 </template>

--- a/src/components/LegendList.vue
+++ b/src/components/LegendList.vue
@@ -15,10 +15,10 @@
     <legend-item id="gridded_lightning"></legend-item>
     <legend-item id="historical_fire_perimeters"></legend-item>
     <legend-item
-      id="alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem"
+      id="alfresco_relative_flammability_cru_ts40_historical_1950_2008_iem"
     ></legend-item>
     <legend-item
-      id="alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099"
+      id="alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099"
     ></legend-item>
   </div>
 </template>

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -198,6 +198,10 @@ export default {
         styles: layer.styles ? layer.styles : "",
         time: layer.time ? layer.time : "",
         id: layer.id,
+
+        // alfresco_relative_flammability_30yr dimensions
+        dim_model: layer.dim_model != null ? layer.dim_model : "",
+        dim_scenario: layer.dim_scenario != null ? layer.dim_scenario : "",
       });
 
       // Remove old layers if present
@@ -207,8 +211,12 @@ export default {
         );
       }
 
+      let wmsServer = layer.rasdaman
+        ? process.env.VUE_APP_RASDAMAN_URL
+        : process.env.VUE_APP_GEOSERVER_WMS_URL;
+
       this.$options.leaflet.layers[layer.id] = this.$L.tileLayer.wms(
-        process.env.VUE_APP_GEOSERVER_WMS_URL,
+        wmsServer,
         layerConfiguration,
       );
     },

--- a/src/layers.js
+++ b/src/layers.js
@@ -258,8 +258,8 @@ export default [
   {
     rasdaman: true,
     abstract: `
-          <p>This layer shows output from ALFRESCO, a computer model that simulates the responses of Northern vegetation to climate change. Darker colors mean a greater chance of a region burning. Model projections are for 2010&ndash;2099 using the <a href="https://www.cesm.ucar.edu/models/ccsm">NCAR CCSM4</a> model under the RCP 8.5 emission scenario. These projections can be useful for planning, particularly when compared to historical flammability and historical fires, but they can’t predict which specific places will burn.</p><p>Source data, including additional models and scenarios, <a href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/eeaaca2c-0280-4226-b126-fda42a2b6214">can be downloaded here</a>.</p>`,
-    id: "alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099",
+          <p>This layer shows output from ALFRESCO, a computer model that simulates the responses of Northern vegetation to climate change. Darker colors mean a greater chance of a region burning. Model projections are for 2070&ndash;2099 using the <a href="https://www.cesm.ucar.edu/models/ccsm">NCAR CCSM4</a> model under the RCP 8.5 emission scenario. These projections can be useful for planning, particularly when compared to historical flammability and historical fires, but they can’t predict which specific places will burn.</p><p>Source data, including additional models and scenarios, <a href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/eeaaca2c-0280-4226-b126-fda42a2b6214">can be downloaded here</a>.</p>`,
+    id: "alfresco_relative_flammability_NCAR-CCSM4_rcp85_2070_2099",
     numericId: 14,
     wmsLayerName: 'alfresco_relative_flammability_30yr',
     dim_model: 6,

--- a/src/layers.js
+++ b/src/layers.js
@@ -235,15 +235,17 @@ export default [
     </table>`,
   },
   {
+    rasdaman: true,
     abstract: `
-          <p>This layer shows output from ALFRESCO, a computer model that simulates the responses of Northern vegetation to climate change. Darker colors mean a greater chance of a region burning. These modeled data for the previous century (1900&ndash;1999) allow for comparison between that century and this one, but do not necessarily match historical fire perimeters.</p>
+          <p>This layer shows output from ALFRESCO, a computer model that simulates the responses of Northern vegetation to climate change. Darker colors mean a greater chance of a region burning. These modeled data for 1950&ndash;2008 allow for comparison with projected data but do not necessarily match historical fire perimeters.</p>
           <p>Source data, including additional models and scenarios, <a href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/eeaaca2c-0280-4226-b126-fda42a2b6214">can be downloaded here</a>.</p>`,
-    id: "alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem",
+    id: "alfresco_relative_flammability_cru_ts40_historical_1950_2008_iem",
     numericId: 13,
-    wmsLayerName:
-      "alaska_wildfires:alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem",
+    wmsLayerName: 'alfresco_relative_flammability_30yr',
+    dim_model: 0,
+    dim_scenario: 0,
     zindex: 5,
-    styles: "flammability",
+    styles: "alaska_wildfire_explorer_historical",
     title: "Historical modeled flammability",
     legend: `<table class="table alaska-wildfires-legend flammability">
       <tr><td><div class="rf-1"></div></td><td>Less likely to burn</td></tr>
@@ -254,14 +256,16 @@ export default [
     </table>`,
   },
   {
+    rasdaman: true,
     abstract: `
-          <p>This layer shows output from ALFRESCO, a computer model that simulates the responses of Northern vegetation to climate change. Darker colors mean a greater chance of a region burning. Model projections are for 2000&ndash;2099 using the <a href="https://www.cesm.ucar.edu/models/ccsm">NCAR CCSM4</a> model under the RCP 8.5 emission scenario. These projections can be useful for planning, particularly when compared to historical flammability and historical fires, but they can’t predict which specific places will burn.</p><p>Source data, including additional models and scenarios, <a href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/eeaaca2c-0280-4226-b126-fda42a2b6214">can be downloaded here</a>.</p>`,
-    id: "alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099",
+          <p>This layer shows output from ALFRESCO, a computer model that simulates the responses of Northern vegetation to climate change. Darker colors mean a greater chance of a region burning. Model projections are for 2010&ndash;2099 using the <a href="https://www.cesm.ucar.edu/models/ccsm">NCAR CCSM4</a> model under the RCP 8.5 emission scenario. These projections can be useful for planning, particularly when compared to historical flammability and historical fires, but they can’t predict which specific places will burn.</p><p>Source data, including additional models and scenarios, <a href="https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/eeaaca2c-0280-4226-b126-fda42a2b6214">can be downloaded here</a>.</p>`,
+    id: "alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099",
     numericId: 14,
-    wmsLayerName:
-      "alaska_wildfires:alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099",
+    wmsLayerName: 'alfresco_relative_flammability_30yr',
+    dim_model: 6,
+    dim_scenario: 3,
     zindex: 5,
-    styles: "flammability",
+    styles: "alaska_wildfire_explorer_projected",
     title: "Projected flammability",
     legend: `<table class="table alaska-wildfires-legend flammability">
       <tr><td><div class="rf-1"></div></td><td>Less likely to burn</td></tr>

--- a/tests/test-suite.spec.js
+++ b/tests/test-suite.spec.js
@@ -380,11 +380,11 @@ test('Historical modeled flammability', async ({ page }) => {
   // Disable current wildfires layer.
   await page.click('#fires a')
 
-  await page.click('#alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem a')
+  await page.click('#alfresco_relative_flammability_cru_ts40_historical_1950_2008_iem a')
 
-  // Check that the most recently added map tiles contain "alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem" in the URL of their src attribute.
+  // Check that the most recently added map tiles contain "alfresco_relative_flammability_cru_ts40_historical_1950_2008_iem" in the URL of their src attribute.
   let src = await page.locator('.leaflet-container .leaflet-layer img').last().getAttribute('src')
-  expect(src).toContain('alfresco_relative_flammability_cru_ts40_historical_1900_1999_iem')
+  expect(src).toContain('alfresco_relative_flammability_cru_ts40_historical_1950_2008_iem')
 
   let legend = page.locator('.legend--item:has(h4:has-text("Historical modeled flammability"))')
   expect(legend).toBeVisible()
@@ -400,11 +400,11 @@ test('Projected flammability', async ({ page }) => {
   // Disable current wildfires layer.
   await page.click('#fires a')
 
-  await page.click('#alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099 a')
+  await page.click('#alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099 a')
 
-  // Check that the most recently added map tiles contain "alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099" in the URL of their src attribute.
+  // Check that the most recently added map tiles contain "alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099" in the URL of their src attribute.
   let src = await page.locator('.leaflet-container .leaflet-layer img').last().getAttribute('src')
-  expect(src).toContain('alfresco_relative_flammability_NCAR-CCSM4_rcp85_2000_2099')
+  expect(src).toContain('alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099')
 
   let legend = page.locator('.legend--item:has(h4:has-text("Projected flammability"))')
   expect(legend).toBeVisible()

--- a/tests/test-suite.spec.js
+++ b/tests/test-suite.spec.js
@@ -400,11 +400,11 @@ test('Projected flammability', async ({ page }) => {
   // Disable current wildfires layer.
   await page.click('#fires a')
 
-  await page.click('#alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099 a')
+  await page.click('#alfresco_relative_flammability_NCAR-CCSM4_rcp85_2070_2099 a')
 
-  // Check that the most recently added map tiles contain "alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099" in the URL of their src attribute.
+  // Check that the most recently added map tiles contain "alfresco_relative_flammability_NCAR-CCSM4_rcp85_2070_2099" in the URL of their src attribute.
   let src = await page.locator('.leaflet-container .leaflet-layer img').last().getAttribute('src')
-  expect(src).toContain('alfresco_relative_flammability_NCAR-CCSM4_rcp85_2010_2099')
+  expect(src).toContain('alfresco_relative_flammability_NCAR-CCSM4_rcp85_2070_2099')
 
   let legend = page.locator('.legend--item:has(h4:has-text("Projected flammability"))')
   expect(legend).toBeVisible()


### PR DESCRIPTION
Closes #39.

This PR updates the webapp to load both the historical and projected ALFRESCO flammability layers from the `alfresco_relative_flammability_30yr` coverage on Rasdaman instead of GeoServer.

Because the `alfresco_relative_flammability_30yr` coverage on Rasdaman uses pre-baked eras, the following historical and projected centuries (from GeoServer):

- 1900-1999
- 2000-2099

Have been changed to

- 1950-2008 (the mean of the two historical eras in `alfresco_relative_flammability_30yr`)
- 2070-2099 (the late-century era, as requested in issue #39)

I've updated the layer ID and text to reflect these changes.

You'll also notice that I had to change the WMS version from `1.3` to `1.3.0` in one place. Rasdaman will not accept version `1.3` without the `.0`, and GeoServer doesn't seem to mind.

To test, load the webapp and confirm that the historical and projected flammability layers continue to work. I've added a new WMS style for each of them to both Zeus and Apollo, using the same color map that we were using on GeoServer so the flammability legend is still correct.