### PR TITLE
Fix/improve Playwright tests and add Playwright instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To install and run this project locally, follow these steps:
 3. Install the required dependencies:
 
    ```
-   npm install
+   npm install --force # Force resolution of Vue 2 / Playwright incompatibilities
    ```
 
 4. Start the application:
@@ -46,13 +46,13 @@ To set the app into "winter mode", export this env var:
 
 ### Playwright tests
 
-To run the Playwright tests for this webapp, first run the webapp:
+To run the Playwright tests for this webapp, set any necesary environment variables, then run the webapp:
 
 ```
 npm run dev
 ```
 
-Then, in another terminal window, run the following
+Make sure the local webapp is running as expected. Then, in another terminal window, run the following
 
 ```
 npx playwright install # Install Playwright browsers

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ To set the app into "winter mode", export this env var:
 
 `export VUE_APP_ACTIVE=False`
 
+### Playwright tests
+
+To run the Playwright tests for this webapp, first run the webapp:
+
+```
+npm run dev
+```
+
+Then, in another terminal window, run the following
+
+```
+npx playwright install # Install Playwright browsers
+npx playwright test --ui
+```
+
 ## Building the repository for production
 
 This repository uses AWS CLI tools to pull the latest version of the status.json file from the production version of the application before building the application. This means that the status.json will match the last time data was updated using our Prefect update scripts.

--- a/tests/test-suite.spec.js
+++ b/tests/test-suite.spec.js
@@ -33,7 +33,7 @@ test('Place selector autocomplete', async ({ page }) => {
   // Wait a bit for autocomplete options to load.
   await page.waitForTimeout(3000)
 
-  await expect(page.locator('.dropdown-menu .dropdown-item')).toHaveCount(1)
+  await expect(page.locator('.dropdown-content .search-item')).toHaveCount(1)
 })
 
 test('Current conditions', async ({ page }) => {

--- a/tests/test-suite.spec.js
+++ b/tests/test-suite.spec.js
@@ -6,7 +6,7 @@ test('Intro text', async ({ page }) => {
   await page.goto(url)
   await page.setViewportSize({ width: 1728, height: 1078 })
 
-  let src = await page.locator('.intro a:has-text("Alaska Interagency Coordination Center")').getAttribute('href')
+  let src = await page.locator('.intro a:text-is("Alaska Interagency Coordination Center")').getAttribute('href')
   expect(src).toContain('https://fire.ak.blm.gov/')
 
   const glowText = await page.locator('.intro .glow').textContent()
@@ -21,7 +21,7 @@ test('Intro text', async ({ page }) => {
   expect(fireCount).toMatch(/^[0-9,]+$/)
   expect(acresBurned).toMatch(/^[0-9,]+$/)
 
-  src = await page.locator('.intro a:has-text("Fire Tally")').getAttribute('href')
+  src = await page.locator('.intro a:text-is("Fire Tally")').getAttribute('href')
   expect(src).toContain('https://snap.uaf.edu/tools/daily-fire-tally')
 })
 
@@ -44,14 +44,12 @@ test('Current conditions', async ({ page }) => {
   // Wait a bit for autocomplete options to load.
   await page.waitForTimeout(3000)
 
-  const results = page.locator('.dropdown-menu .dropdown-item:has(div:has-text("Fairbanks"))')
-
   await page.click('.dropdown-menu .dropdown-item:has(div:text-is("Fairbanks"))')
 
   // Wait a bit for data to load.
   await page.waitForTimeout(3000)
 
-  let src = await page.locator('.intro a:has-text("Fire danger")').getAttribute('href')
+  let src = await page.locator('.intro a:text-is("Fire danger")').getAttribute('href')
   expect(src).toContain('https://en.wikipedia.org/wiki/National_Fire_Danger_Rating_System')
 
   await expect(page.locator('.intro table')).toHaveCount(2)
@@ -71,7 +69,7 @@ test('Active wildfires layer', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.active-fires)')
   expect(legend).toBeVisible()
 
-  let src = await legend.locator('a:has-text("data services")').getAttribute('href')
+  let src = await legend.locator('a:text-is("data services")').getAttribute('href')
   expect(src).toContain('https://fire.ak.blm.gov/predsvcs/maps.php')
 
   // Test disabling of wildfires layer.
@@ -90,19 +88,19 @@ test('Hotspots layer', async ({ page }) => {
 
   await expect(page.locator('.leaflet-container .leaflet-heatmap-layer')).toBeVisible()
 
-  let legend = page.locator('.legend--item:has(h4:has-text("Hotspots, last 48 hours"))')
+  let legend = page.locator('.legend--item:has(h4:text-is("Hotspots, last 48 hours"))')
   expect(legend).toBeVisible()
 
   let src = await legend.locator('img').last().getAttribute('src')
   expect(src).toContain('hotspot-legend')
 
-  src = await legend.locator('a:has-text("NOAA Active Fire Detections from the VIIRS sensor")').getAttribute('href')
+  src = await legend.locator('a:text-is("NOAA Active Fire Detections from the VIIRS sensor")').getAttribute('href')
   expect(src).toContain('https://www.ospo.noaa.gov/Products/land/afiband.html')
 
-  src = await legend.locator('a:has-text("data services")').getAttribute('href')
+  src = await legend.locator('a:text-is("data services")').getAttribute('href')
   expect(src).toContain('https://fire.ak.blm.gov/predsvcs/maps.php')
 
-  src = await legend.locator('a:has-text("VIIRS Active Fire Detection")').getAttribute('href')
+  src = await legend.locator('a:text-is("VIIRS Active Fire Detection")').getAttribute('href')
   expect(src).toContain('https://gina.alaska.edu/wp-content/uploads/2022/05/VIIRS_ActiveFiresAlgorithm_Quick_Guide.pdf')
 })
 
@@ -122,7 +120,7 @@ test('Lightning strikes layer', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.lightning)')
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("data services")').getAttribute('href')
+  src = await legend.locator('a:text-is("data services")').getAttribute('href')
   expect(src).toContain('https://fire.ak.blm.gov/predsvcs/maps.php')
 })
 
@@ -142,7 +140,7 @@ test('Fire danger layer', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.smokey-bear)')
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("layers provided by MesoWest Alaska Fires & Fuels website")').getAttribute('href')
+  src = await legend.locator('a:text-is("layers provided by MesoWest Alaska Fires & Fuels website")').getAttribute('href')
   expect(src).toContain('https://akff.mesowest.org')
 })
 
@@ -159,16 +157,16 @@ test('Air quality sensor network layer', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.aqi-forecast)').nth(0)
   expect(legend).toBeVisible()
 
-  let src = await legend.locator('a:has-text("Air Quality Index (AQI)")').getAttribute('href')
+  let src = await legend.locator('a:text-is("Air Quality Index (AQI)")').getAttribute('href')
   expect(src).toContain('https://www.airnow.gov/aqi/aqi-basics/')
 
-  src = await legend.locator('a:has-text("Read more here")').getAttribute('href')
+  src = await legend.locator('a:text-is("Read more here")').getAttribute('href')
   expect(src).toContain('https://www.epa.gov/pm-pollution/particulate-matter-pm-basics')
 
-  src = await legend.locator('a:has-text("Learn more about how to protect yourself and your family")').getAttribute('href')
+  src = await legend.locator('a:text-is("Learn more about how to protect yourself and your family")').getAttribute('href')
   expect(src).toContain('https://health.alaska.gov/dph/Epi/eph/Documents/airquality/FAQ-Wildfire-Smoke-and-Your-Health.pdf')
 
-  src = await legend.locator('a:has-text("PurpleAir")').getAttribute('href')
+  src = await legend.locator('a:text-is("PurpleAir")').getAttribute('href')
   expect(src).toContain('https://www2.purpleair.com/')
 })
 
@@ -190,13 +188,13 @@ test('6-hour air quality forecast layer', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.aqi-forecast)').nth(1)
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("Read more here")').getAttribute('href')
+  src = await legend.locator('a:text-is("Read more here")').getAttribute('href')
   expect(src).toContain('https://www.epa.gov/pm-pollution/particulate-matter-pm-basics')
 
-  src = await legend.locator('a:has-text("Learn more about how to protect yourself and your family")').getAttribute('href')
+  src = await legend.locator('a:text-is("Learn more about how to protect yourself and your family")').getAttribute('href')
   expect(src).toContain('https://health.alaska.gov/dph/Epi/eph/Documents/airquality/FAQ-Wildfire-Smoke-and-Your-Health.pdf')
 
-  src = await legend.locator('a:has-text("online data portal in the NASA Center for Climate Simulation")').getAttribute('href')
+  src = await legend.locator('a:text-is("online data portal in the NASA Center for Climate Simulation")').getAttribute('href')
   expect(src).toContain('https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php')
 
 })
@@ -217,13 +215,13 @@ test('12-hour air quality forecast layer', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.aqi-forecast)').nth(2)
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("Read more here")').getAttribute('href')
+  src = await legend.locator('a:text-is("Read more here")').getAttribute('href')
   expect(src).toContain('https://www.epa.gov/pm-pollution/particulate-matter-pm-basics')
 
-  src = await legend.locator('a:has-text("Learn more about how to protect yourself and your family")').getAttribute('href')
+  src = await legend.locator('a:text-is("Learn more about how to protect yourself and your family")').getAttribute('href')
   expect(src).toContain('https://health.alaska.gov/dph/Epi/eph/Documents/airquality/FAQ-Wildfire-Smoke-and-Your-Health.pdf')
 
-  src = await legend.locator('a:has-text("online data portal in the NASA Center for Climate Simulation")').getAttribute('href')
+  src = await legend.locator('a:text-is("online data portal in the NASA Center for Climate Simulation")').getAttribute('href')
   expect(src).toContain('https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php')
 })
 
@@ -243,13 +241,13 @@ test('24-hour air quality forecast layer', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.aqi-forecast)').nth(3)
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("Read more here")').getAttribute('href')
+  src = await legend.locator('a:text-is("Read more here")').getAttribute('href')
   expect(src).toContain('https://www.epa.gov/pm-pollution/particulate-matter-pm-basics')
 
-  src = await legend.locator('a:has-text("Learn more about how to protect yourself and your family")').getAttribute('href')
+  src = await legend.locator('a:text-is("Learn more about how to protect yourself and your family")').getAttribute('href')
   expect(src).toContain('https://health.alaska.gov/dph/Epi/eph/Documents/airquality/FAQ-Wildfire-Smoke-and-Your-Health.pdf')
 
-  src = await legend.locator('a:has-text("online data portal in the NASA Center for Climate Simulation")').getAttribute('href')
+  src = await legend.locator('a:text-is("online data portal in the NASA Center for Climate Simulation")').getAttribute('href')
   expect(src).toContain('https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php')
 })
 
@@ -269,13 +267,13 @@ test('48-hour air quality forecast layer', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.aqi-forecast)').nth(4)
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("Read more here")').getAttribute('href')
+  src = await legend.locator('a:text-is("Read more here")').getAttribute('href')
   expect(src).toContain('https://www.epa.gov/pm-pollution/particulate-matter-pm-basics')
 
-  src = await legend.locator('a:has-text("Learn more about how to protect yourself and your family")').getAttribute('href')
+  src = await legend.locator('a:text-is("Learn more about how to protect yourself and your family")').getAttribute('href')
   expect(src).toContain('https://health.alaska.gov/dph/Epi/eph/Documents/airquality/FAQ-Wildfire-Smoke-and-Your-Health.pdf')
 
-  src = await legend.locator('a:has-text("online data portal in the NASA Center for Climate Simulation")').getAttribute('href')
+  src = await legend.locator('a:text-is("online data portal in the NASA Center for Climate Simulation")').getAttribute('href')
   expect(src).toContain('https://gmao.gsfc.nasa.gov/GMAO_products/NRT_products.php')
 })
 
@@ -295,7 +293,7 @@ test('Snow cover', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.snow-cover)')
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("Visit the data source")').getAttribute('href')
+  src = await legend.locator('a:text-is("Visit the data source")').getAttribute('href')
   expect(src).toContain('https://usicecenter.gov/Resources/ImsInfo')
 })
 
@@ -315,7 +313,7 @@ test('Land cover types', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.alaska-landcover-2015)')
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("North American Land Change Monitoring System, 2015")').getAttribute('href')
+  src = await legend.locator('a:text-is("North American Land Change Monitoring System, 2015")').getAttribute('href')
   expect(src).toContain('https://eros.usgs.gov/doi-remote-sensing-activities/2019/usgs/nalcms-release-new-land-cover-north-america')
 })
 
@@ -346,10 +344,10 @@ test('Historical lightning strikes', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.lightning-climatology)')
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("this academic paper")').getAttribute('href')
+  src = await legend.locator('a:text-is("this academic paper")').getAttribute('href')
   expect(src).toContain('https://journals.ametsoc.org/view/journals/apme/59/6/JAMC-D-19-0209.1.xml')
 
-  src = await legend.locator('a:has-text("the dataset can be downloaded here")').getAttribute('href')
+  src = await legend.locator('a:text-is("the dataset can be downloaded here")').getAttribute('href')
   expect(src).toContain('https://search.dataone.org/view/10.24431_rw1k45z_2020_7_23_23548')
 })
 
@@ -369,7 +367,7 @@ test('Historical fire perimeters', async ({ page }) => {
   let legend = page.locator('.legend--item:has(table.historical-fire-perimeters)')
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("data services")').getAttribute('href')
+  src = await legend.locator('a:text-is("data services")').getAttribute('href')
   expect(src).toContain('https://fire.ak.blm.gov/predsvcs/maps.php')
 })
 
@@ -386,10 +384,10 @@ test('Historical modeled flammability', async ({ page }) => {
   let src = await page.locator('.leaflet-container .leaflet-layer img').last().getAttribute('src')
   expect(src).toContain('alfresco_relative_flammability_cru_ts40_historical_1950_2008_iem')
 
-  let legend = page.locator('.legend--item:has(h4:has-text("Historical modeled flammability"))')
+  let legend = page.locator('.legend--item:has(h4:text-is("Historical modeled flammability"))')
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("can be downloaded here")').getAttribute('href')
+  src = await legend.locator('a:text-is("can be downloaded here")').getAttribute('href')
   expect(src).toContain('https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/eeaaca2c-0280-4226-b126-fda42a2b6214')
 })
 
@@ -406,10 +404,10 @@ test('Projected flammability', async ({ page }) => {
   let src = await page.locator('.leaflet-container .leaflet-layer img').last().getAttribute('src')
   expect(src).toContain('alfresco_relative_flammability_NCAR-CCSM4_rcp85_2070_2099')
 
-  let legend = page.locator('.legend--item:has(h4:has-text("Projected flammability"))')
+  let legend = page.locator('.legend--item:has(h4:text-is("Projected flammability"))')
   expect(legend).toBeVisible()
 
-  src = await legend.locator('a:has-text("can be downloaded here")').getAttribute('href')
+  src = await legend.locator('a:text-is("can be downloaded here")').getAttribute('href')
   expect(src).toContain('https://catalog.snap.uaf.edu/geonetwork/srv/eng/catalog.search#/metadata/eeaaca2c-0280-4226-b126-fda42a2b6214')
 })
 
@@ -417,64 +415,64 @@ test('Footer links', async ({ page }) => {
   await page.goto(url)
   await page.setViewportSize({ width: 1728, height: 1078 })
 
-  let src = await page.locator('.footer a:has-text("Alaska Interagency Coordination Center")').first().getAttribute('href')
+  let src = await page.locator('.footer a:text-is("Alaska Interagency Coordination Center")').first().getAttribute('href')
   expect(src).toContain('https://fire.ak.blm.gov/aicc.php')
 
-  src = await page.locator('.footer a:has-text("MesoWest data services")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("MesoWest data services")').getAttribute('href')
   expect(src).toContain('https://mesowest.utah.edu')
 
-  src = await page.locator('.footer a:has-text("Global Modeling and Assimilation Office (GMAO)")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("Global Modeling and Assimilation Office (GMAO)")').getAttribute('href')
   expect(src).toContain('https://gmao.gsfc.nasa.gov/')
 
-  src = await page.locator('.footer a:has-text("PurpleAir")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("PurpleAir")').getAttribute('href')
   expect(src).toContain('https://www2.purpleair.com/')
 
-  src = await page.locator('.footer a:has-text("Geographic Information Network of Alaska")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("Geographic Information Network of Alaska")').getAttribute('href')
   expect(src).toContain('https://gina.alaska.edu')
 
-  src = await page.locator('.footer a:has-text("NOAA")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("NOAA")').getAttribute('href')
   expect(src).toContain('https://www.nesdis.noaa.gov/about/our-offices/office-of-low-earth-orbit-observations')
 
-  src = await page.locator('.footer a:has-text("Alaska Fire Service")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("Alaska Fire Service")').getAttribute('href')
   expect(src).toContain('https://www.blm.gov/programs/fire-and-aviation/regional-info/alaska-fire-service')
 
-  src = await page.locator('.footer a:has-text("Alaska Interagency Coordination Center")').last().getAttribute('href')
+  src = await page.locator('.footer a:text-is("Alaska Interagency Coordination Center")').last().getAttribute('href')
   expect(src).toContain('https://fire.ak.blm.gov')
 
-  src = await page.locator('.footer a:has-text("Scenarios Network for Alaska and Arctic Planning")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("Scenarios Network for Alaska and Arctic Planning")').getAttribute('href')
   expect(src).toContain('https://www.snap.uaf.edu/')
 
-  src = await page.locator('.footer a:has-text("Alaska Climate Adaptation Science Center")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("Alaska Climate Adaptation Science Center")').getAttribute('href')
   expect(src).toContain('https://akcasc.org')
 
-  src = await page.locator('.footer a:has-text("Institute for Circumpolar Health Studies")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("Institute for Circumpolar Health Studies")').getAttribute('href')
   expect(src).toContain('https://www.uaa.alaska.edu/academics/college-of-health/departments/population-health-sciences/institute-for-circumpolar-health-studies')
 
-  src = await page.locator('.footer a:has-text("Center for Disaster Resilient Communities")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("Center for Disaster Resilient Communities")').getAttribute('href')
   expect(src).toContain('https://cdrc.uw.edu')
 
-  src = await page.locator('.footer a:has-text("EPA Grant Number R840479")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("EPA Grant Number R840479")').getAttribute('href')
   expect(src).toContain('https://cfpub.epa.gov/ncer_abstracts/index.cfm/fuseaction/display.abstractDetail/abstract_id/11349')
 
-  src = await page.locator('.footer a:has-text("International Arctic Research Center")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("International Arctic Research Center")').getAttribute('href')
   expect(src).toContain('https://uaf-iarc.org/')
 
-  src = await page.locator('.footer a:has-text("University of Alaska Fairbanks")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("University of Alaska Fairbanks")').getAttribute('href')
   expect(src).toContain('https://uaf.edu/uaf/')
 
-  src = await page.locator('.footer a:has-text("uaf-snap-data-tools@alaska.edu")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("uaf-snap-data-tools@alaska.edu")').getAttribute('href')
   expect(src).toContain('mailto:uaf-snap-data-tools@alaska.edu')
 
-  src = await page.locator('.footer a:has-text("Visit the SNAP Climate + Weather Tools page")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("Visit the SNAP Climate + Weather Tools page")').getAttribute('href')
   expect(src).toContain('https://uaf-snap.org/tools-overview/')
 
-  src = await page.locator('.footer a:has-text("Statement of Nondiscrimination")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("University of Alaska")').getAttribute('href')
+  expect(src).toContain('https://www.alaska.edu/')
+
+  src = await page.locator('.footer a:text-is("policy of non-discrimination")').getAttribute('href')
   expect(src).toContain('https://www.alaska.edu/nondiscrimination/')
 
-  src = await page.locator('.footer a:has-text("Privacy Statement")').getAttribute('href')
-  expect(src).toContain('https://www.alaska.edu/records/records/compliance/gdpr/ua-privacy-statement/')
-
-  src = await page.locator('.footer a:has-text("Learn more about UA’s notice of web accessibility")').getAttribute('href')
+  src = await page.locator('.footer a:text-is("Learn more about UA’s notice of web accessibility")').getAttribute('href')
   expect(src).toContain('https://www.alaska.edu/webaccessibility/')
 
 })


### PR DESCRIPTION
This PR fixes a couple existing Playwright tests, including:

- The test to confirm that only "Fairbanks" appears in the community input autocomplete when you enter "Fairb" (confirming that pan-Arctic communities are not included, basically).
- The test that checks the non-discrimination text in the footer, since this was changed recently.

The following new tests are also added:
- A test to confirm that the GMU boundary layer is loaded if "GMUs" is selected from the boundary layer dropdown. @BobTorgerson, I know you're putting more work into this feature at the moment, but I think this test may continue to work after your changes. Or require just a small tweak.
- A test to confirm that the community ID and layer list passed in via permalinks are received and loaded properly.

I've also switched to using `text-is` instead of `has-text` throughout all of the tests. This was motivated by the tests getting hung up on the difference between "University of Alaska" and "University of Alaska Fairbanks" in the footer. In retrospect, all cases of `has-text` should have been `is-text` to begin with, and all tests still pass with this change.

To test this PR, make sure that the new Playwright instructions added to the README are sufficient to get up and running with Playwright, and confirm that all tests pass.

Also, I'm starting to think the granularity of these tests is nearing "overkill" territory, but the original intention was to make it easier to port this app to Vue 3 without missing a thing. I still stand by this, but we may want to trim the tests back after the Vue 3 port 🤔 