### PR TITLE
Removes the Protected Areas layer

### DIFF
--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -67,9 +67,6 @@
         <map-layer id="gmu"></map-layer>
       </li>
       <li>
-        <map-layer id="protected_areas"></map-layer>
-      </li>
-      <li>
         <map-layer id="fire_zones"></map-layer>
       </li>
     </ul>

--- a/src/components/LegendList.vue
+++ b/src/components/LegendList.vue
@@ -21,7 +21,6 @@
       id="alfresco_relative_flammability_NCAR-CCSM4_rcp85_2070_2099"
     ></legend-item>
     <legend-item id="gmu"></legend-item>
-    <legend-item id="protected_areas"></legend-item>
     <legend-item id="fire_zones"></legend-item>
   </div>
 </template>

--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -91,11 +91,10 @@ export default {
         });
       } else if (
         this.id === "gmu" ||
-        this.id === "protected_areas" ||
         this.id === "fire_zones"
       ) {
         // When a boundary layer is toggled, turn off all other boundary layers
-        const boundaryLayers = ["gmu", "protected_areas", "fire_zones"];
+        const boundaryLayers = ["gmu", "fire_zones"];
         boundaryLayers.forEach((layerId) => {
           if (layerId !== this.id) {
             this.$store.commit("setLayerVisibility", {

--- a/src/layers.js
+++ b/src/layers.js
@@ -322,14 +322,6 @@ export default [
       `,
   },
   {
-    id: "protected_areas",
-    numericId: 17,
-    wmsLayerName: "all_boundaries:all_protected_areas",
-    title: "Protected Areas",
-    zindex: 100,
-    abstract: `<p>Protected areas include National Parks, National Forests, Wilderness Areas, National Wildlife Refuges, State Parks.  These are identified by multiple State and Federal agencies, including the National Park Service (NPS), Alaska Department of Fish and Game (ADFG), United States Forest Service (USFS), and more.</p>`,
-  },
-  {
     id: "fire_zones",
     numericId: 18,
     wmsLayerName: "all_boundaries:all_fire_zones",


### PR DESCRIPTION
To test:

 - Run the app, check that Protected Areas doesn't show up in the layer list anymore.
 - Search codebase for any fragments of Protected Area, it shouldn't be present.
