### PR TITLE
Updates Purple Air legend to have a solid green square for good air quality.

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -1061,6 +1061,29 @@ table.alaska-wildfires-legend {
     }
   }
 
+  &.purple-air {
+    td div {
+      &.aqi-good {
+        background-color: rgb(0, 228, 0);
+      }
+      &.aqi-moderate {
+        background-color: rgb(255, 255, 0);
+      }
+      &.aqi-unhealthy-sg {
+        background-color: rgb(255, 126, 0);
+      }
+      &.aqi-unhealthy {
+        background-color: rgb(255, 0, 0);
+      }
+      &.aqi-very-unhealthy {
+        background-color: rgb(143, 63, 151);
+      }
+      &.aqi-hazardous {
+        background-color: rgb(126, 0, 35);
+      }
+    }
+  }
+
   &.aqi-forecast {
     td div {
       &.aqi-good {

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -1061,29 +1061,6 @@ table.alaska-wildfires-legend {
     }
   }
 
-  &.purple-air {
-    td div {
-      &.aqi-good {
-        background-color: rgb(0, 228, 0);
-      }
-      &.aqi-moderate {
-        background-color: rgb(255, 255, 0);
-      }
-      &.aqi-unhealthy-sg {
-        background-color: rgb(255, 126, 0);
-      }
-      &.aqi-unhealthy {
-        background-color: rgb(255, 0, 0);
-      }
-      &.aqi-very-unhealthy {
-        background-color: rgb(143, 63, 151);
-      }
-      &.aqi-hazardous {
-        background-color: rgb(126, 0, 35);
-      }
-    }
-  }
-
   &.aqi-forecast {
     td div {
       &.aqi-good {
@@ -1103,6 +1080,15 @@ table.alaska-wildfires-legend {
       }
       &.aqi-hazardous {
         background-color: rgb(126, 0, 35);
+      }
+    }
+  }
+
+  &.purple-air {
+    @extend .aqi-forecast;
+    td div {
+      &.aqi-good {
+        background-color: rgb(0, 228, 0);
       }
     }
   }

--- a/src/layers.js
+++ b/src/layers.js
@@ -19,7 +19,7 @@ const aqiTable = `
   <table class="table alaska-wildfires-legend aqi-forecast">
     <tr><td><div class="aqi-good"></div></td><td>Good: 0&ndash;50</td></tr>
     <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51&ndash;100</td></tr>
-    <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101&ndash;150</td></tr>
+    <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Sensitive Groups: 101&ndash;150</td></tr>
     <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151&ndash;200</td></tr>
     <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201&ndash;300</td></tr>
     <tr><td><div class="aqi-hazardous"></div></td><td>Hazardous: 301&ndash;500</td></tr>
@@ -312,7 +312,7 @@ export default [
     <table class="table alaska-wildfires-legend purple-air">
       <tr><td><div class="aqi-good"></div></td><td>Good: 0&ndash;50</td></tr>
       <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51&ndash;100</td></tr>
-      <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101&ndash;150</td></tr>
+      <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Sensitive Groups: 101&ndash;150</td></tr>
       <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151&ndash;200</td></tr>
       <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201&ndash;300</td></tr>
       <tr><td><div class="aqi-hazardous"></div></td><td>Hazardous: 301&ndash;500</td></tr>

--- a/src/layers.js
+++ b/src/layers.js
@@ -52,7 +52,7 @@ const activeFiresLayerTable = `
     </tr>
   </tbody>
   </table>
-`
+`;
 
 export default [
   {
@@ -308,7 +308,15 @@ export default [
     title: "Air quality sensor network",
     blurb: "updated every 10 minutes",
     zindex: 20,
-    legend: aqiTable,
+    legend: `
+    <table class="table alaska-wildfires-legend purple-air">
+      <tr><td><div class="aqi-good"></div></td><td>Good: 0&ndash;50</td></tr>
+      <tr><td><div class="aqi-moderate"></div></td><td>Moderate: 51&ndash;100</td></tr>
+      <tr><td><div class="aqi-unhealthy-sg"></div></td><td>Unhealthy for Senstitive Groups: 101&ndash;150</td></tr>
+      <tr><td><div class="aqi-unhealthy"></div></td><td>Unhealthy: 151&ndash;200</td></tr>
+      <tr><td><div class="aqi-very-unhealthy"></div></td><td>Very Unhealthy: 201&ndash;300</td></tr>
+      <tr><td><div class="aqi-hazardous"></div></td><td>Hazardous: 301&ndash;500</td></tr>
+    </table>`,
     legendClassOverride: "is-one-third",
   },
   {


### PR DESCRIPTION
This PR changes the Purple Air legend to have a solid green square for good air quality. We were previously using the AQI forecast legend colors which had a green border but a blank background color. 

Closes #198 