### PR TITLE
Adds CrazyEgg to AWE

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,11 @@
       content="https://alaskawildfires.org/images/rupp-munson-fire.jpeg"
     />
     <script
+      type="text/javascript"
+      src="//script.crazyegg.com/pages/scripts/0126/7664.js"
+      async="async"
+    ></script>
+    <script
       async
       defer
       data-website-id="b811e2fb-e9a9-4547-8c53-59a75b01cd9d"


### PR DESCRIPTION
This PR adds the call to the CrazyEgg JS in the head element of the site to allow for CrazyEgg to run for anonymous users. 