### PR TITLE
Fixes summary overflows for the fire popups in the Firefox browser

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -828,11 +828,13 @@ export default {
 
 .leaflet-popup-content {
   z-index: 1000;
+  min-width: 200px;
+  max-width: 400px;
 
   .fire-summary {
-    width: 30vh;
-    max-height: 30vh;
-    overflow-y: scroll;
+    width: 100%;
+    max-height: 200px;
+    overflow-y: auto;
     white-space: pre-wrap;
   }
 

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -828,12 +828,12 @@ export default {
 
 .leaflet-popup-content {
   z-index: 1000;
-  min-width: 200px;
-  max-width: 400px;
+  min-width: 20vh;
+  max-width: 30vh;
 
   .fire-summary {
     width: 100%;
-    max-height: 200px;
+    max-height: 30vh;
     overflow-y: auto;
     white-space: pre-wrap;
   }


### PR DESCRIPTION
This PR fixes the summary overflows in the fire popups when using the Firefox browswer. This was not repeatable in other browsers, but was definitely a problem.

To see the issue, change the .env.development file to this:
```
VUE_APP_GEOSERVER_WMS_URL=https://gs.earthmaps.io/geoserver/wms
VUE_APP_GEOSERVER_WFS_URL=https://gs.earthmaps.io/geoserver/wfs
VUE_APP_RASDAMAN_URL=https://maps.earthmaps.io/rasdaman/ows
VUE_APP_ACTIVE=true
```
Next, run the code from the main branch first and view it in a private window in Firefox:
```
git checkout main
npm run dev
```
Note that several of the popups for the fire points and polygons will overflow past the underlying div. 

Now, change to this branch and try again in the private window in Firefox:
```
git checkout fix_summary_overflow
npm run dev
```
Now the text won't go beyond the defined width of the containing div.

Closes #194 