### PR TITLE
Removes VIIRS AOD from available layers.

### DIFF
--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -41,9 +41,6 @@
           </li>
         </ul>
       </li>
-      <li>
-        <map-layer id="viirs_aod"></map-layer>
-      </li>
     </ul>
     <h3 class="title is-4">Past &amp; future</h3>
     <ul>

--- a/src/components/LegendList.vue
+++ b/src/components/LegendList.vue
@@ -11,7 +11,6 @@
     <legend-item id="aqi_forecast_12_hrs"></legend-item>
     <legend-item id="aqi_forecast_24_hrs"></legend-item>
     <legend-item id="aqi_forecast_48_hrs"></legend-item>
-    <legend-item id="viirs_aod"></legend-item>
     <legend-item id="snow_cover_3338"></legend-item>
     <legend-item id="alaska_landcover_2015"></legend-item>
     <legend-item id="gridded_lightning"></legend-item>

--- a/src/layers.js
+++ b/src/layers.js
@@ -363,28 +363,6 @@ export default [
       `,
   },
   {
-    id: "viirs_aod",
-    numericId: 19,
-    wmsLayerName: "alaska_wildfires:viirs_aod",
-    title: "VIIRS aerosol optical depth",
-    zindex: 5,
-    abstract: `
-      <p>
-        The VIIRS aerosol optical depth (AOD) layer is a quantitative indicator of aerosol loading in the atmosphere. It is a unitless value that ranges from 0 to 1, with higher values of AOD indicating higher concentrations of aerosols. These aerosols can include smoke, blowing dust, and other fine particulates. This product can help operational users who provide warnings, watches and advisories for dust, smoke, and haze related to visibility and air quality.
-      </p>
-      <p>This layer is updated every day.</p>
-      <p>Data provided by the <a href="https://www.star.nesdis.noaa.gov/atmospheric-composition-training/index.php">NOAA Aerosols and Atmospheric Composition Science Team</a>.</p>
-      <p>Read a <a href="https://www.star.nesdis.noaa.gov/atmospheric-composition-training/documents/VIIRS_Aerosol_Optical_Depth_Quick_Guide.pdf">fact sheet about this layer</a>.</p>
-      `,
-    legend: `<table class="table alaska-wildfires-legend viirs-aod">
-      <tr><td><div class="aod-1"></div></td><td>&lt; 0.2 Clean Air</td></tr>
-      <tr><td><div class="aod-2"></div></td><td>0.2 &ndash; 0.4 Light aerosol loading</td></tr>
-      <tr><td><div class="aod-3"></div></td><td>0.4 &ndash; 0.6 Moderate aerosol loading</td></tr>
-      <tr><td><div class="aod-4"></div></td><td>0.6 &ndash; 0.8 High aerosol loading</td></tr>
-      <tr><td><div class="aod-5"></div></td><td>&gt; 0.8 Very high aerosol loading</td></tr>
-    </table>`,
-  },
-  {
     id: "viirs_adp",
     numericId: 20,
     wmsLayerName: "alaska_wildfires:viirs_adp",


### PR DESCRIPTION
This PR is in response to feedback from Micah and Theresa regarding the ADP being the more valuable of the two layers to show to the end users. This simply removes the VIIRS AOD from the available layers and now only the smoke plumes will remain in the Smoke and Air Quality section.

Closes #216 