### PR TITLE
Credit third parties in DEC-hosted sensor popups where necessary, and change DEC link target

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -125,6 +125,13 @@ const aqiColorRanges = [
   },
 ];
 
+const decTypes = [
+  "dec",
+  "conocophillips",
+  "blm",
+  "louden_tribe"
+];
+
 export default {
   name: "AK_Fires",
   components: {
@@ -301,13 +308,6 @@ export default {
         ) {
           return false;
         }
-
-        const decTypes = [
-          "dec",
-          "conocophillips",
-          "blm",
-          "louden_tribe"
-        ];
 
         var icon;
         if (decTypes.includes(feature.properties.type)) {

--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -302,8 +302,15 @@ export default {
           return false;
         }
 
+        const decTypes = [
+          "dec",
+          "conocophillips",
+          "blm",
+          "louden_tribe"
+        ];
+
         var icon;
-        if (feature.properties.type == "dec") {
+        if (decTypes.includes(feature.properties.type)) {
           icon = this.$L.divIcon({
             className: "aqi-dec",
             popupAnchor: [15, -5],
@@ -327,7 +334,17 @@ export default {
 
         // Create popup content
         var popupContent;
-        if (feature.properties.type == "dec") {
+        if (decTypes.includes(feature.properties.type)) {
+          var dataProvider;
+          if (feature.properties.type == "conocophillips") {
+            dataProvider = `<a href="https://www.conocophillips.com/">ConocoPhillips</a>`;
+          } else if (feature.properties.type == "blm") {
+            dataProvider = `<a href="https://www.blm.gov/">Bureau of Land Management</a>`;
+          } else if (feature.properties.type == "louden_tribe") {
+            dataProvider = `<a href="https://www.loudentribe.org/">Louden Tribe</a>`;
+          } else {
+            dataProvider = `<a href="https://dec.alaska.gov/air/air-monitoring/instruments-sites/community-based-monitoring/">Department of Environmental Conservation</a>`;
+          }
           popupContent = `<div class="${aqi24hrClassInfo.class} sensor-detail">
             <p><strong>1-hour average PM2.5 AQI</strong> at this sensor on ${this.convertToAKST(
               feature.properties.lastupdate,
@@ -338,7 +355,7 @@ export default {
           } &mdash; ${aqi1hrClassInfo.name}</span>
             </p>
             <p class="aqi-explain">${aqi1hrClassInfo.description}</p>
-            <p>Data provided by a <a href="https://dec.alaska.gov/air/air-monitoring/">Department of Environmental Conservation</a> sensor.</p>
+            <p>Data provided by a ${dataProvider} sensor.</p>
           </div>`;
         } else {
           popupContent = `

--- a/src/layers.js
+++ b/src/layers.js
@@ -38,7 +38,7 @@ const sensorNetworkLayerTable = `
       <div class="aqi-hazardous dec"></div>
     </td>
     <td>
-      <strong>Circles</strong> show data from the Alaska Department of Environmental Conservation, 1 hour average AQI.
+      <strong>Circles</strong> show data hosted by the Alaska Department of Environmental Conservation, 1 hour average AQI.
     </td>
   </tr>
 </table>
@@ -320,7 +320,7 @@ export default [
     <p>This layer shows sensor values for the <a href="https://www.airnow.gov/aqi/aqi-basics/">Air Quality Index (AQI)</a>, an indicator of how polluted the air is. The AQI is based on the local concentration of particulate matter that is 2.5 micrometers or smaller (PM<sub>2.5</sub>). These tiny particles can be inhaled and cause serious health problems. <a href="https://www.epa.gov/pm-pollution/particulate-matter-pm-basics">Read more here</a>.</p>
     <p>The layer shows the average AQI over the last 10 minutes or 1 hour at each sensor location. The 24-hour average AQI can be seen if you click on any of the sensors with a square icon.</p>
     <p>The air quality shown on these sensors can be affected by a variety of pollution sources. Smoke from wildfires is a major source of air pollution in Alaska, but PM<sub>2.5</sub> can also come from industry, cars, or wood stoves.</p>
-    <p>The data in this layer are measured using air quality sensors. These include <a href="https://map.purpleair.com/air-quality-standards-us-epa-aqi?opt=%2F1%2Flp%2Fa10%2Fp604800%2FcC0#1/11.5/-30">PurpleAir sensors</a> that are hosted by communities and made public, and sensors run by the <a href="https://dec.alaska.gov/air/air-monitoring/">Alaska Department of Environmental Conservation</a>, including regulatory monitors and Quant MODULAIR pods provided to their Community-Based Air Monitoring Network.</p>
+    <p>The data in this layer are measured using air quality sensors. These include <a href="https://map.purpleair.com/air-quality-standards-us-epa-aqi?opt=%2F1%2Flp%2Fa10%2Fp604800%2FcC0#1/11.5/-30">PurpleAir sensors</a> that are hosted by communities and made public, and sensors hosted by the <a href="https://dec.alaska.gov/air/air-monitoring/instruments-sites/community-based-monitoring/">Alaska Department of Environmental Conservation</a>, including regulatory monitors and Quant MODULAIR pods provided to their Community-Based Air Monitoring Network.</p>
     <p>If you would like to add your sensor network to this map, please contact the <a href="mailto:uaf-snap-data-tools@alaska.edu">SNAP team.</a></p>
     `,
     id: "purple_air",


### PR DESCRIPTION
Closes #224.
Xref: https://github.com/ua-snap/prefect/pull/63

This PR makes the changes requested in #224:

- The webapp code has been updated to recognize the new sensor types implemented in https://github.com/ua-snap/prefect/pull/63 (`conocophillips`, `blm`, and `louden_tribe`)
- Each of the new sensor types still show up as a DEC/circle marker on the map, but the "Current air quality" legend has been updated to indicate that these are sensors _hosted_ by DEC, not necessarily _run_ by DEC.
- The popups for the `conocophillips`, `blm`, and `louden_tribe` markers now credit their respective organizations, with a link to the organization's website.

To test, I've uploaded a sample output from https://github.com/ua-snap/prefect/pull/63 to gs-dev.earthmaps.io as `playground:purple_air_dec`, so change this line:

https://github.com/ua-snap/alaska-wildfires/blob/0bc5cf2170103ea4d66c027331fe9ec1ac304a5d/src/components/FireMap.vue#L224

To this:

```
typeName: "playground:purple_air_dec",
```

Then make sure your `.env.development` is pointing at gs-dev.earthmaps.io, not gs.earthmaps.io.

Run the app and click the circle markers at the following places to see the new third-party credits:

- Kaktovik
- Nuiqsut
- Galena (there are two overlapping circle markers here, so be sure to zoom in as much as you can)

