### PR TITLE
Remove links to Fire Tally webapp

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,14 +44,6 @@
                 season.</span
               >
             </p>
-            <p>
-              To compare the current fire year to high fire years since 2004,
-              visit the
-              <a href="https://snap.uaf.edu/tools/daily-fire-tally"
-                >Fire Tally</a
-              >
-              tool.
-            </p>
             <p class="intro--legend">
               <img src="@/assets/active-perimeter.svg" />Active fires with
               mapped perimeters have a &lsquo;halo&rsquo; to show relative size.
@@ -154,14 +146,6 @@
                     Northern Climate Reports
                   </a>
                   tool.
-                </li>
-                <li>
-                  Our
-                  <a href="https://snap.uaf.edu/tools/daily-fire-tally"
-                    >Fire Tally tool</a
-                  >, developed in partnership with the Alaska Interagency
-                  Coordination Center, displays historical acres burned for
-                  different wildfire seasons across different areas in Alaska.
                 </li>
                 <li>
                   Our

--- a/tests/test-suite.spec.js
+++ b/tests/test-suite.spec.js
@@ -51,9 +51,6 @@ test('Intro text', async ({ page }) => {
   src = await page.locator('.intro a:text-is("Alaska Interagency Coordination Center")').getAttribute('href')
   expect(src).toContain('https://fire.ak.blm.gov/')
 
-  src = await page.locator('.intro a:text-is("Fire Tally")').getAttribute('href')
-  expect(src).toContain('https://snap.uaf.edu/tools/daily-fire-tally')
-
   src = await page.locator('a:text-is("protect yourself and your family from wildfire smoke")').getAttribute('href')
   expect(src).toContain('https://uaf-snap.org/project/epa-star-wfe')
 })


### PR DESCRIPTION
This PR removes all links to our Fire Tally webapp, which is currently inactivate because no data has been made available for 2025. To test:

- Run the app locally and verify that the Fire Tally link/blurb is no longer present in the intro text near the top
- Set `export VUE_APP_ACTIVE=False` and run the app again to verify that the Fire Tally link has been removed from Alaska Wildfire Explorer's "tool offline" mode

I've also removed the test for this link from the Playwright tests.