### PR TITLE
Re-orders the layer list and legend list for the Smoke & Air Quality section.

### DIFF
--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -17,9 +17,6 @@
       <hr />
       <h3 class="title is-4 top">Smoke and Air Quality</h3>
       <li>
-        <map-layer id="viirs_adp"></map-layer>
-      </li>
-      <li>
         <map-layer id="purple_air"></map-layer>
       </li>
       <li class="mt-2">
@@ -40,6 +37,9 @@
             <map-layer small="small" id="aqi_forecast_48_hrs"></map-layer>
           </li>
         </ul>
+      </li>
+      <li>
+        <map-layer id="viirs_adp"></map-layer>
       </li>
     </ul>
     <h3 class="title is-4">Past &amp; future</h3>

--- a/src/components/LegendList.vue
+++ b/src/components/LegendList.vue
@@ -5,12 +5,12 @@
     <legend-item id="viirs"></legend-item>
     <legend-item id="lightning_strikes"></legend-item>
     <legend-item id="spruceadj_3338"></legend-item>
-    <legend-item id="viirs_adp"></legend-item>
     <legend-item id="purple_air"></legend-item>
     <legend-item id="aqi_forecast_6_hrs"></legend-item>
     <legend-item id="aqi_forecast_12_hrs"></legend-item>
     <legend-item id="aqi_forecast_24_hrs"></legend-item>
     <legend-item id="aqi_forecast_48_hrs"></legend-item>
+    <legend-item id="viirs_adp"></legend-item>
     <legend-item id="snow_cover_3338"></legend-item>
     <legend-item id="alaska_landcover_2015"></legend-item>
     <legend-item id="gridded_lightning"></legend-item>


### PR DESCRIPTION
This PR updates the order of the layers in the Smoke & Air Quality section of the AWE. The order is now:

* Current air quality
* Forecast air quality
* Current smoke plumes

Closes #238 