### PR TITLE
Reloads local layers to grab new data when a community is entered

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -125,12 +125,7 @@ const aqiColorRanges = [
   },
 ];
 
-const decTypes = [
-  "dec",
-  "conocophillips",
-  "blm",
-  "louden_tribe"
-];
+const decTypes = ["dec", "conocophillips", "blm", "louden_tribe"];
 
 export default {
   name: "AK_Fires",
@@ -170,6 +165,9 @@ export default {
         purple_air: purpleAirLayerGroup,
       };
     },
+    reloadLocalLayers() {
+      return this.$store.state.reloadLocalLayers;
+    },
   },
   data() {
     return {
@@ -207,12 +205,18 @@ export default {
     this.$store.commit("clearSelected");
   },
   mounted() {
-    this.fetchFireData();
-    this.fetchViirsData();
-    this.fetchPurpleAirData();
+    this.loadLocalLayers();
 
     // Remove any stray localStorage.
     localStorage.clear();
+  },
+  watch: {
+    reloadLocalLayers(bool) {
+      if (bool) {
+        this.loadLocalLayers();
+        this.$store.commit("clearReloadLocalLayers");
+      }
+    },
   },
   methods: {
     // Helper function to format incoming UNIX timestamps
@@ -220,6 +224,12 @@ export default {
     // object for formatting relevant in context.
     parseDate(t) {
       return this.$moment(parseInt(t)).utcOffset(offset);
+    },
+
+    loadLocalLayers() {
+      this.fetchFireData();
+      this.fetchViirsData();
+      this.fetchPurpleAirData();
     },
 
     fetchPurpleAirData() {

--- a/src/store.js
+++ b/src/store.js
@@ -82,6 +82,9 @@ export default new Vuex.Store({
     // which is refreshed by an external process that will
     // update the S3 bucket in production.
     updateStatus: undefined,
+
+    // Trigger for refreshing local layers when a new place is selected
+    reloadLocalLayers: false,
   },
   mutations: {
     // This function is used to initialize the layers in the store.
@@ -191,6 +194,10 @@ export default new Vuex.Store({
     },
     setSelected(state, selected) {
       state.selected = selected;
+      state.reloadLocalLayers = true;
+    },
+    clearReloadLocalLayers(state) {
+      state.reloadLocalLayers = false;
     },
     setApiOutput(state, apiOutput) {
       state.apiOutput = apiOutput;


### PR DESCRIPTION
This PR adds a new variable in the Vuex store that is watched for by the FireMap component to reload the local layers that are generated upon initial page load. These three layers are:
* 2025 Wildfires
* Hotspots, last 48 hours
* Current air quality

This change will make it so that if someone has left the AWE open for even 10 minutes, the new data will be picked up when they next choose a community to view. 