### PR TITLE
Adds summary field to pop-ups when clicking on a fire polygon.

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -526,6 +526,7 @@ export default {
             updated: feature.properties.updated,
             outdate: feature.properties.OUTDATE,
             discovered: feature.properties.discovered,
+            summary: feature.properties.SUMMARY,
           }),
         );
       };


### PR DESCRIPTION
This PR adds the summary field to the pop-ups for the fire layer when clicking on a fire polygon. On the live site, if you click on any portion of the polygon that isn't covered by the fire size indicator bubble, the summary is missing. With this addition, the summaries are included and the pop-ups match for all portions of a fire polygon. 

To test, change your .env.development file to match this:
```
VUE_APP_GEOSERVER_WMS_URL=https://gs.earthmaps.io/geoserver/wms
VUE_APP_GEOSERVER_WFS_URL=https://gs.earthmaps.io/geoserver/wfs
VUE_APP_RASDAMAN_URL=https://zeus.snap.uaf.edu/rasdaman/ows
VUE_APP_ACTIVE=true
```