### PR TITLE
Changes basemap for mobile browsers

### DIFF
--- a/src/components/FireMap.vue
+++ b/src/components/FireMap.vue
@@ -146,7 +146,6 @@ export default {
       if (isMobile()) {
         return this.$L.CRS.EPSG3857;
       } else {
-        // Alaska Albers Equal Area
         return new this.$L.Proj.CRS(
           "EPSG:3338",
           "+proj=aea +lat_1=55 +lat_2=65 +lat_0=50 +lon_0=-154 +x_0=0 +y_0=0 +ellps=GRS80 +datum=NAD83 +units=m +no_defs",


### PR DESCRIPTION
This PR changes the basemap for mobile browsers to a EPSG:3857 projection while leaving the desktop version of the site in a EPSG:3338 projection with our OSM tiles. 

For testing, you can build the application and run a Python HTTP server + ngrok to test on your phone and desktop browser.
`npm run build`
`cd dist && python -m http.server 8080`
`ngrok http 8080`

You should expect to see two different base layers for the maps in the mobile vs the desktop browsers.

Closes #247 