### PR TITLE
Fixes issue where blocked umami script would cause the layers to be unclickable

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -292,6 +292,16 @@ import PlaceSelector from "@/components/PlaceSelector.vue";
 import FireAPIOutput from "@/components/FireAPIOutput";
 import Footer from "@/components/Footer";
 
+// When the app renders, it's possible the user's browser blocks our Umami script.
+// If that's true, ensure there is a stub to prevent the app breaking.
+if (!window.umami || !window.umami.track) {
+  window.umami = {
+    track: () => {
+      return; // no-op
+    },
+  };
+}
+
 export default {
   name: "App",
   components: { FireMap, PlaceSelector, FireAPIOutput, Footer },


### PR DESCRIPTION
Closes #263 

(Change the base to whatever accumulator branch if desired before merging).

Testing:
 1. Install uBlock Origin in a clean browser instance (ideally), best would be Firefox
 2. Run the `main` branch (to recreate the issue)
 3. Run the app and test that you see the original behavior: toggling map layers or clicking on AQI markers wouldn't work

Once you see the original issue, switch to this branch and the app should be OK:
 - Can click to toggle layers
 - Can click on markers for air quality