### PR TITLE
Converts anchor link used for clickable map layer to a span to prevent possible SEO penalties for uncrawlable links.

### DIFF
--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -11,7 +11,7 @@
 
     <!-- Layer title! -->
     <span class="layer-title">
-      <a @click.prevent="toggleLayer(id)">
+      <span @click="toggleLayer(id)">
         <span v-if="layer.visible">&#10003;&nbsp;</span>
         <span
           v-html="layer.title"
@@ -20,7 +20,7 @@
           }"
         >
         </span>
-      </a>
+      </span>
     </span>
 
     <!-- Blurb for extra info if activated -->
@@ -122,10 +122,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-a:hover {
-  text-decoration: none;
-}
-
 .layer {
   margin: 5px 0;
   cursor: pointer;
@@ -142,9 +138,7 @@ a:hover {
 
 .visible {
   font-weight: 900;
-  text-shadow:
-    #f4d609 1px 1px 7px,
-    #f4d609 -1px -1px 7px;
+  text-shadow: #f4d609 1px 1px 7px, #f4d609 -1px -1px 7px;
 }
 
 .layer-title {

--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -7,8 +7,6 @@
       small: small,
     }"
   >
-    <!-- Below, we need @click.prevent because of this: https://github.com/vuejs/vue/issues/3699 -->
-
     <!-- Layer title! -->
     <span class="layer-title">
       <span @click="toggleLayer(id)">

--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -9,7 +9,7 @@
   >
     <!-- Layer title! -->
     <span class="layer-title">
-      <span @click="toggleLayer(id)">
+      <span @click="toggleLayer()" role="button">
         <span v-if="layer.visible">&#10003;&nbsp;</span>
         <span
           v-html="layer.title"


### PR DESCRIPTION
This PR replaces the anchor links <a> with a <span> in the map layer code to prevent possible SEO penalties that come with uncrawlable links. The functionality remains the same but will not incur any penalties.

Closes #135 